### PR TITLE
Feature: Task flow Id

### DIFF
--- a/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/ConcurrencyMiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/ConcurrencyMiddlewareCancellationTests.swift
@@ -98,7 +98,8 @@ private extension ConcurrencyMiddlewareCancellationTests {
             switch state.middlewareFlow {
             case .loading:
                 execute(
-                    SomeEffect(id: "message_id"),
+                    effect: SomeEffect(),
+                    flowId: "message_id",
                     cancellation: Сancellation.message
                 )
 
@@ -110,16 +111,14 @@ private extension ConcurrencyMiddlewareCancellationTests {
             }
         }
 
-        struct SomeEffect<Id: Hashable>: ConcurrencyEffect {
-            var id: Id
-
-            func task() async throws -> any Action {
+        struct SomeEffect: ConcurrencyEffect {
+            func task(flowId: AnyHashable) async throws -> any UDF.Action {
                 try await Task.sleep(seconds: 1)
-
+                
                 try Task.checkCancellation()
-
-                return Actions.Message(message: "Success message", id: id)
+                
+                return Actions.Message(message: "Success message", id: flowId)
             }
         }
     }
-}
+} 

--- a/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/ConcurrencyMiddlewareTaskIdTests.swift
+++ b/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/ConcurrencyMiddlewareTaskIdTests.swift
@@ -1,0 +1,110 @@
+import Combine
+import XCTest
+
+@testable import UDF
+
+final class ConcurrencyMiddlewareTaskIdTests: XCTestCase {
+    struct AppState: AppReducer {
+        var middlewareFlow = MiddlewareFlow()
+        var runForm = RunForm()
+    }
+    
+    enum MiddlewareFlow: IdentifiableFlow {
+        case none, loading, didLoad
+        
+        init() { self = .none }
+        
+        mutating func reduce(_ action: some Action) {
+            switch action {
+            case is Actions.Loading:
+                self = .loading
+                
+            case let action as Actions.DidFinishLoading where action.id == Self.id:
+                self = .didLoad
+                
+            default:
+                break
+            }
+        }
+    }
+    
+    struct RunForm: Form {
+        var loadedCount: Int = 0
+        
+        mutating func reduce(_ action: some Action) {
+            switch action {
+            case let action as Actions.DidFinishLoading where action.id == MiddlewareFlow.id:
+                loadedCount += 1
+                
+            default:
+                break
+            }
+        }
+    }
+    
+    func testReducibleMiddlewareTaskId() async {
+        let store = await XCTestStore(initial: AppState())
+        await store.subscribe(TestReducibleMiddleware.self)
+        
+        var runForm = await store.state.runForm
+        XCTAssertEqual(runForm.loadedCount, 0)
+        
+        await store.dispatch(Actions.Loading(id: MiddlewareFlow.id))
+        await store.wait()
+        
+        runForm = await store.state.runForm
+        XCTAssertEqual(runForm.loadedCount, 1)
+    }
+}
+
+private extension Actions {
+    struct Loading: Action {
+        let id: AnyHashable
+    }
+    struct DidFinishLoading: Action {
+        let id: AnyHashable
+    }
+}
+
+// MARK: - Middlewares
+private extension ConcurrencyMiddlewareTaskIdTests {
+    final class TestReducibleMiddleware: BaseReducibleMiddleware<AppState> {
+        struct Environment {
+            var loadItems: () async -> [String]
+        }
+        
+        var environment: Environment!
+        
+        static func buildLiveEnvironment(for store: some Store<AppState>) -> Environment {
+            Environment(loadItems: { [] })
+        }
+        
+        static func buildTestEnvironment(for store: some Store<AppState>) -> Environment {
+            Environment(loadItems: { [] })
+        }
+        
+        enum Cancellation: CaseIterable {
+            case loading
+        }
+        
+        func reduce(_ action: some Action, for state: ConcurrencyMiddlewareTaskIdTests.AppState) {
+            switch action {
+            case let action as Actions.Loading:
+                execute(
+                    effect: SomeEffect(),
+                    flowId: action.id,
+                    cancellation: Cancellation.loading
+                )
+                
+            default:
+                break
+            }
+        }
+        
+        struct SomeEffect: ConcurrencyEffect {
+            func task(flowId: AnyHashable) async throws -> any Action {
+                return Actions.DidFinishLoading(id: flowId)
+            }
+        }
+    }
+}

--- a/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/MiddlewareMapErrorTests.swift
+++ b/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/MiddlewareMapErrorTests.swift
@@ -46,7 +46,7 @@ final class MiddlewareMapErrorTests: XCTestCase {
             switch action {
             case is Actions.StartLoading:
                 execute(
-                    id: MiddlewareMapErrorTests.AppState.ErrorFlow.id,
+                    flowId: MiddlewareMapErrorTests.AppState.ErrorFlow.id,
                     cancellation: Сancellation.message,
                     mapError: mapAPIError
                 ) { _ in

--- a/Tests/SwiftUI-UDF-Tests/BindableReducers/BindableReducersMiddlewareTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/BindableReducers/BindableReducersMiddlewareTests.swift
@@ -164,7 +164,7 @@ private extension BindableReducersMiddlewareTests {
             for (id, flow) in state.itemsFlow {
                 switch flow {
                 case .loading:
-                    execute(id: ItemsFlow.id, cancellation: Cancellation.itemDetails(id)) { flowId in
+                    execute(flowId: ItemsFlow.id, cancellation: Cancellation.itemDetails(id)) { flowId in
                         let item = try await self.environment.loadItemDetails(id)
                         return Actions.DidLoadItem(item: item, id: flowId)
                             .binded(to: ItemsContainer.self, by: id)

--- a/UDF/Middleware/Effect/ConcurrencyEffect.swift
+++ b/UDF/Middleware/Effect/ConcurrencyEffect.swift
@@ -43,16 +43,11 @@ import Foundation
 /// }
 /// ```
 public protocol ConcurrencyEffect {
-    /// The type of the unique identifier for the effect.
-    associatedtype Id: Hashable
-
-    /// The unique identifier for this effect.
-    var id: Id { get }
-
     /// An asynchronous method that performs a task and returns an action.
     ///
+    /// - Parameter flowId: The unique identifier for the flow.
     /// - Returns: An action produced by the asynchronous task.
-    func task() async throws -> any Action
+    func task(flowId: AnyHashable) async throws -> any Action
 }
 
 /// A concrete implementation of `ConcurrencyEffect` that runs an asynchronous block of code to produce an action.
@@ -60,25 +55,21 @@ public protocol ConcurrencyEffect {
 /// `ConcurrencyBlockEffect` encapsulates an asynchronous block, allowing you to define custom logic for the effect's task.
 /// It conforms to both `ConcurrencyEffect` and `FileFunctionLine`, making it possible to track the source location where the effect was
 /// created.
-struct ConcurrencyBlockEffect<EffectId: Hashable>: ConcurrencyEffect, FileFunctionLine {
-    typealias Id = EffectId
-
-    /// The unique identifier for this effect.
-    var id: EffectId
-
+struct ConcurrencyBlockEffect: ConcurrencyEffect, FileFunctionLine {
     /// The asynchronous block to be executed, producing an action.
-    let block: (EffectId) async throws -> any Action
-
+    let block: (AnyHashable) async throws -> any Action
+    
     // Metadata for debugging: file name, function name, and line number.
     var fileName: String
     var functionName: String
     var lineNumber: Int
-
-    /// Executes the asynchronous block with the effect's `id`.
+    
+    /// Executes the asynchronous block with the provided `flowId`.
     ///
+    /// - Parameter flowId: The unique identifier for the flow.
     /// - Returns: An action produced by the asynchronous block.
     /// - Throws: An error if the block fails to complete successfully.
-    func task() async throws -> any Action {
-        try await block(id)
+    func task(flowId: AnyHashable) async throws -> any Action {
+        try await block(flowId)
     }
 }


### PR DESCRIPTION
I have made an update to make writing effects easier. Now, instead of each effect needing its own ID, we pass the flowId directly to the task method.

**Simplified `ConcurrencyEffect` Protocol:**
- Removed the need for an id property in effects
- Now, the task method gets a flowId when it's called

**Updated `ConcurrencyBlockEffect`:**
- Took out the id property to match the new protocol
- The block now uses flowId in the task method

**Changed `execute` Functions:**
- Adjusted them to pass flowId to the effect's task method
- Made sure they handle errors and cancellations correctly with the new setup