### PR TITLE
Add invalid index test for moveItem

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/PaginatorTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/PaginatorTests.swift
@@ -169,4 +169,17 @@ class PaginatorTests: XCTestCase {
         XCTAssertTrue(isMovedIntoBeginning)
         XCTAssertEqual(itemAt10Index, try XCTUnwrap(paginator.items.first))
     }
+
+    func testMoveItemInvalidIndices() {
+        var paginator = Paginator(Item.self, flowId: ItemFlow.id, perPage: 10)
+        let items = Item.fakeItems(count: 5)
+
+        paginator.reduce(Actions.SetPaginationItems<Item>(items: items, id: ItemFlow.id))
+
+        let negativeResult = paginator.moveItem(fromIndex: -1, toIndex: 0)
+        XCTAssertFalse(negativeResult)
+
+        let outOfBoundsResult = paginator.moveItem(fromIndex: items.count, toIndex: 0)
+        XCTAssertFalse(outOfBoundsResult)
+    }
 }

--- a/UDF/Common/Pagination/Paginator.swift
+++ b/UDF/Common/Pagination/Paginator.swift
@@ -126,7 +126,13 @@ public struct Paginator<Item: Hashable & Identifiable, FlowId: Hashable>: Reduci
     /// - Returns: A Boolean value indicating whether the item was successfully moved.
     @discardableResult
     public mutating func moveItem(fromIndex: Int, toIndex: Int) -> Bool {
-        guard toIndex < items.count, toIndex >= 0, items.count > 0 else {
+        guard
+            fromIndex >= 0,
+            fromIndex < items.count,
+            toIndex < items.count,
+            toIndex >= 0,
+            items.count > 0
+        else {
             return false
         }
         let item = items.elements[fromIndex]


### PR DESCRIPTION
## Summary
- update `moveItem` in `Paginator` to validate `fromIndex`
- add a test for moving items with invalid source indices

## Testing
- `swift test -l` *(fails: Failed to clone repository https://github.com/apple/swift-collections)*