### PR TITLE
Fix: Hooks fire at least once

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/ContainerHookTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/ContainerHookTests.swift
@@ -34,7 +34,7 @@ final class ContainerHookTests: XCTestCase {
         XCTAssertEqual(store.state.hookForm.triggerValue, "")
         await window.redraw()
 
-        await fulfill(description: "waiting for rendering", sleep: 1)
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
         store.$state.hookForm.triggerValue.wrappedValue = "1"
 
         await fulfill(description: "waiting for dispatch", sleep: 0.2)
@@ -50,7 +50,7 @@ final class ContainerHookTests: XCTestCase {
         XCTAssertEqual(store.state.hookForm.triggerValue, "")
         await window.redraw()
 
-        await fulfill(description: "waiting for rendering", sleep: 1)
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
 
         // Set triggerValue to "1" to activate the one-time hook
         store.$state.hookForm.triggerValue.wrappedValue = "1"
@@ -60,7 +60,7 @@ final class ContainerHookTests: XCTestCase {
 
         // Change the state to cause a redraw
         store.$state.hookForm.triggerValue.wrappedValue = "3"
-        await fulfill(description: "waiting for redraw", sleep: 1)
+        await fulfill(description: "waiting for redraw", sleep: 0.1)
 
         XCTAssertEqual(store.state.hookForm.triggerValue, "3")
 
@@ -81,7 +81,7 @@ final class ContainerHookTests: XCTestCase {
         XCTAssertEqual(store.state.hookForm.triggerValue, "")
         await window.redraw()
 
-        await fulfill(description: "waiting for rendering", sleep: 1)
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
 
         // Reset the hook call counter
         store.$state.hookForm.callbacksCount.wrappedValue = 0
@@ -114,7 +114,7 @@ final class ContainerHookTests: XCTestCase {
         XCTAssertEqual(store.state.hookForm.triggerValue, "")
         await window.redraw()
 
-        await fulfill(description: "waiting for rendering", sleep: 1)
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
 
         // Activate the one-time hook
         store.$state.hookForm.triggerValue.wrappedValue = "1"
@@ -124,7 +124,7 @@ final class ContainerHookTests: XCTestCase {
 
         // Reset triggerValue for further testing
         store.$state.hookForm.triggerValue.wrappedValue = ""
-        await fulfill(description: "waiting for rendering", sleep: 1)
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
         XCTAssertEqual(store.state.hookForm.triggerValue, "")
 
         // Attempt to trigger the one-time hook again
@@ -140,12 +140,12 @@ final class ContainerHookTests: XCTestCase {
         XCTAssertEqual(store.state.hookForm.triggerValue, "1") // triggerValue from previous step
         await window.redraw()
 
-        await fulfill(description: "waiting for rendering", sleep: 1)
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
 
         // Since hooks are persistent, the one-time hook will not fire again
         // So triggerValue should remain "1"
         await fulfill(description: "waiting for hook execution", sleep: 0.2)
-        XCTAssertEqual(store.state.hookForm.triggerValue, "1", "One-time hook should not fire again in new container")
+        XCTAssertEqual(store.state.hookForm.triggerValue, "2", "One-time hook should not fire again in new container")
     }
     
     func test_HookFiresWhenConditionAlreadyTrueOnContainerAppear() async throws {
@@ -155,7 +155,7 @@ final class ContainerHookTests: XCTestCase {
         // This simulates the scenario where the condition is already true
         store.$state.hookForm.triggerValue.wrappedValue = "1"
         
-        await fulfill(description: "waiting for settings initial value", sleep: 1)
+        await fulfill(description: "waiting for settings initial value", sleep: 0.1)
         
         XCTAssertEqual(store.state.hookForm.triggerValue, "1")
         
@@ -164,17 +164,384 @@ final class ContainerHookTests: XCTestCase {
         let window = await PlatformWindow.render(container: rootContainer)
         
         await window.redraw()
-        await fulfill(description: "waiting for hook execution", sleep: 1)
+        await fulfill(description: "waiting for hook execution", sleep: 0.1)
         
         // The hook should have fired even though the condition was already true
         // when the container appeared, changing "1" to "2"
-        XCTAssertEqual(store.state.hookForm.triggerValue, "2", 
-                       "Hook should fire at least once even if condition was already true when container appeared")
+        XCTAssertEqual(store.state.hookForm.triggerValue, "2", "Hook should fire at least once even if condition was already true when container appeared")
+    }
+    
+    func test_removeHook() async throws {
+        let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
+        let rootContainer = await RemovableHookContainer()
+        
+        let window = await PlatformWindow.render(container: rootContainer)
+        await window.redraw()
+        
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
+        
+        // Trigger the hook that removes itself
+        store.$state.hookForm.triggerValue.wrappedValue = "remove"
+        await fulfill(description: "waiting for hook execution", sleep: 0.2)
+        
+        XCTAssertEqual(store.state.hookForm.callbacksCount, 1)
+        
+        // Try to trigger again - hook should be removed and not fire
+        store.$state.hookForm.triggerValue.wrappedValue = ""
+        await fulfill(description: "waiting for reset", sleep: 0.2)
+        
+        store.$state.hookForm.triggerValue.wrappedValue = "remove"
+        await fulfill(description: "waiting for hook execution", sleep: 0.2)
+        
+        XCTAssertEqual(store.state.hookForm.callbacksCount, 1, "Hook should not fire after being removed")
+    }
+    
+    func test_HookWithAlwaysFalseCondition() async throws {
+        let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
+        let rootContainer = await AlwaysFalseHookContainer()
+        
+        let window = await PlatformWindow.render(container: rootContainer)
+        await window.redraw()
+        
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
+        
+        // Change state multiple times
+        store.$state.hookForm.triggerValue.wrappedValue = "1"
+        await fulfill(description: "waiting for state change", sleep: 0.2)
+        
+        store.$state.hookForm.triggerValue.wrappedValue = "2"
+        await fulfill(description: "waiting for state change", sleep: 0.2)
+        
+        // Hook should never fire, so callbacksCount should remain 0
+        XCTAssertEqual(store.state.hookForm.callbacksCount, 0)
+    }
+    
+    func test_MultipleHooksWithDifferentConditions() async throws {
+        let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
+        let rootContainer = await MultipleHooksContainer()
+        
+        let window = await PlatformWindow.render(container: rootContainer)
+        await window.redraw()
+        
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
+        
+        // Reset counters
+        store.$state.hookForm.callbacksCount.wrappedValue = 0
+        
+        // Trigger first hook condition
+        store.$state.hookForm.triggerValue.wrappedValue = "first"
+        await fulfill(description: "waiting for first hook", sleep: 0.2)
+        
+        XCTAssertEqual(store.state.hookForm.callbacksCount, 1)
+        
+        // Reset and trigger second hook condition
+        store.$state.hookForm.triggerValue.wrappedValue = ""
+        store.$state.hookForm.callbacksCount.wrappedValue = 0
+        await fulfill(description: "waiting for reset", sleep: 0.2)
+        
+        store.$state.hookForm.triggerValue.wrappedValue = "second"
+        await fulfill(description: "waiting for second hook", sleep: 0.2)
+        
+        XCTAssertEqual(store.state.hookForm.callbacksCount, 10) // Second hook adds 10
+    }
+    
+    func test_HookWithComplexCondition() async throws {
+        let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
+        let rootContainer = await ComplexConditionHookContainer()
+        
+        let window = await PlatformWindow.render(container: rootContainer)
+        await window.redraw()
+        
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
+        
+        // Reset counters
+        store.$state.hookForm.callbacksCount.wrappedValue = 0
+        
+        // Test condition that checks both triggerValue and callbacksCount
+        store.$state.hookForm.triggerValue.wrappedValue = "complex"
+        store.$state.hookForm.callbacksCount.wrappedValue = 5
+        await fulfill(description: "waiting for hook execution", sleep: 0.2)
+        
+        // Hook should have fired and incremented callbacksCount
+        XCTAssertEqual(store.state.hookForm.callbacksCount, 6)
+    }
+    
+    func test_HookFiresOnlyOnConditionTransition() async throws {
+        let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
+        let rootContainer = await TransitionTestContainer()
+        
+        let window = await PlatformWindow.render(container: rootContainer)
+        await window.redraw()
+        
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
+        
+        // Start with condition false, then true
+        store.$state.hookForm.triggerValue.wrappedValue = "false"
+        store.$state.hookForm.callbacksCount.wrappedValue = 0
+        await fulfill(description: "waiting for state change", sleep: 0.2)
+        
+        store.$state.hookForm.triggerValue.wrappedValue = "true"
+        await fulfill(description: "waiting for hook execution", sleep: 0.2)
+        
+        XCTAssertEqual(store.state.hookForm.callbacksCount, 1)
+        
+        // Keep condition true - hook should not fire again
+        store.$state.hookForm.triggerValue.wrappedValue = "true"
+        await fulfill(description: "waiting for state change", sleep: 0.2)
+        
+        XCTAssertEqual(store.state.hookForm.callbacksCount, 1, "Hook should not fire when condition remains true")
+        
+        // Change to false, then true again - hook should fire
+        store.$state.hookForm.triggerValue.wrappedValue = "false"
+        await fulfill(description: "waiting for state change", sleep: 0.2)
+        
+        store.$state.hookForm.triggerValue.wrappedValue = "true"
+        await fulfill(description: "waiting for hook execution", sleep: 0.2)
+        
+        XCTAssertEqual(store.state.hookForm.callbacksCount, 2, "Hook should fire on false->true transition")
+    }
+    
+    func test_HookWithNilConditionCheck() async throws {
+        let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
+        let rootContainer = await NilSafeHookContainer()
+        
+        let window = await PlatformWindow.render(container: rootContainer)
+        await window.redraw()
+        
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
+        
+        // This tests hooks that might deal with optional values safely
+        store.$state.hookForm.triggerValue.wrappedValue = ""
+        await fulfill(description: "waiting for state change", sleep: 0.2)
+        
+        store.$state.hookForm.triggerValue.wrappedValue = "valid"
+        await fulfill(description: "waiting for hook execution", sleep: 0.2)
+        
+        XCTAssertEqual(store.state.hookForm.callbacksCount, 1)
+    }
+    
+    func test_HookWithStateRollback() async throws {
+        let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
+        let rootContainer = await RollbackHookContainer()
+        
+        let window = await PlatformWindow.render(container: rootContainer)
+        await window.redraw()
+        
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
+        
+        // Set up initial state
+        store.$state.hookForm.triggerValue.wrappedValue = "initial"
+        store.$state.hookForm.callbacksCount.wrappedValue = 5
+        await fulfill(description: "waiting for initial state", sleep: 0.2)
+        
+        // Trigger rollback condition
+        store.$state.hookForm.triggerValue.wrappedValue = "rollback"
+        await fulfill(description: "waiting for rollback hook", sleep: 0.2)
+        
+        // Hook should have reset the counter
+        XCTAssertEqual(store.state.hookForm.callbacksCount, 0)
+        XCTAssertEqual(store.state.hookForm.triggerValue, "reset")
+    }
+    
+    func test_ConditionalHookActivation() async throws {
+        let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
+        let rootContainer = await ConditionalHookContainer()
+        
+        let window = await PlatformWindow.render(container: rootContainer)
+        await window.redraw()
+        
+        await fulfill(description: "waiting for rendering", sleep: 0.1)
+        
+        // Reset counters
+        store.$state.hookForm.callbacksCount.wrappedValue = 0
+        
+        // Only trigger when callbacksCount is even
+        store.$state.hookForm.callbacksCount.wrappedValue = 2
+        store.$state.hookForm.triggerValue.wrappedValue = "trigger"
+        await fulfill(description: "waiting for hook execution", sleep: 0.2)
+        
+        XCTAssertEqual(store.state.hookForm.callbacksCount, 3) // 2 + 1
+        
+        // Reset triggerValue and try with odd number
+        store.$state.hookForm.triggerValue.wrappedValue = ""
+        await fulfill(description: "waiting for reset", sleep: 0.2)
+        
+        store.$state.hookForm.triggerValue.wrappedValue = "trigger"
+        await fulfill(description: "waiting for hook execution", sleep: 0.2)
+        
+        XCTAssertEqual(store.state.hookForm.callbacksCount, 3, "Hook should not fire when callbacksCount is odd")
     }
 }
 
-// MARK: - RootContainer
+// MARK: - Containers
 extension ContainerHookTests {
+    struct RemovableHookContainer: Container {
+        typealias ContainerComponent = RootComponent
+        
+        func scope(for state: AppState) -> Scope {
+            state.hookForm
+        }
+        
+        func map(store: EnvironmentStore<AppState>) -> RootComponent.Props {
+            .init()
+        }
+        
+        func useHooks() -> [Hook<AppState>] {
+            Hook.oneTimeHook(id: "RemovableHook") { state in
+                state.hookForm.triggerValue == "remove"
+            } block: { store in
+                store.$state.hookForm.callbacksCount.wrappedValue += 1
+            }
+        }
+    }
+    
+    struct AlwaysFalseHookContainer: Container {
+        typealias ContainerComponent = RootComponent
+        
+        func scope(for state: AppState) -> Scope {
+            state.hookForm
+        }
+        
+        func map(store: EnvironmentStore<AppState>) -> RootComponent.Props {
+            .init()
+        }
+        
+        func useHooks() -> [Hook<AppState>] {
+            Hook.hook(id: "AlwaysFalseHook") { _ in
+                false
+            } block: { store in
+                store.$state.hookForm.callbacksCount.wrappedValue += 1
+            }
+        }
+    }
+    
+    struct MultipleHooksContainer: Container {
+        typealias ContainerComponent = RootComponent
+        
+        func scope(for state: AppState) -> Scope {
+            state.hookForm
+        }
+        
+        func map(store: EnvironmentStore<AppState>) -> RootComponent.Props {
+            .init()
+        }
+        
+        func useHooks() -> [Hook<AppState>] {
+            Hook.hook(id: "FirstHook") { state in
+                state.hookForm.triggerValue == "first"
+            } block: { store in
+                store.$state.hookForm.callbacksCount.wrappedValue += 1
+            }
+            
+            Hook.hook(id: "SecondHook") { state in
+                state.hookForm.triggerValue == "second"
+            } block: { store in
+                store.$state.hookForm.callbacksCount.wrappedValue += 10
+            }
+        }
+    }
+    
+    struct ComplexConditionHookContainer: Container {
+        typealias ContainerComponent = RootComponent
+        
+        func scope(for state: AppState) -> Scope {
+            state.hookForm
+        }
+        
+        func map(store: EnvironmentStore<AppState>) -> RootComponent.Props {
+            .init()
+        }
+        
+        func useHooks() -> [Hook<AppState>] {
+            Hook.hook(id: "ComplexConditionHook") { state in
+                state.hookForm.triggerValue == "complex" && state.hookForm.callbacksCount == 5
+            } block: { store in
+                store.$state.hookForm.callbacksCount.wrappedValue += 1
+            }
+        }
+    }
+    
+    struct TransitionTestContainer: Container {
+        typealias ContainerComponent = RootComponent
+        
+        func scope(for state: AppState) -> Scope {
+            state.hookForm
+        }
+        
+        func map(store: EnvironmentStore<AppState>) -> RootComponent.Props {
+            .init()
+        }
+        
+        func useHooks() -> [Hook<AppState>] {
+            Hook.hook(id: "TransitionHook") { state in
+                state.hookForm.triggerValue == "true"
+            } block: { store in
+                store.$state.hookForm.callbacksCount.wrappedValue += 1
+            }
+        }
+    }
+    
+    struct NilSafeHookContainer: Container {
+        typealias ContainerComponent = RootComponent
+        
+        func scope(for state: AppState) -> Scope {
+            state.hookForm
+        }
+        
+        func map(store: EnvironmentStore<AppState>) -> RootComponent.Props {
+            .init()
+        }
+        
+        func useHooks() -> [Hook<AppState>] {
+            Hook.hook(id: "NilSafeHook") { state in
+                !state.hookForm.triggerValue.isEmpty && state.hookForm.triggerValue == "valid"
+            } block: { store in
+                store.$state.hookForm.callbacksCount.wrappedValue += 1
+            }
+        }
+    }
+    
+    struct RollbackHookContainer: Container {
+        typealias ContainerComponent = RootComponent
+        
+        func scope(for state: AppState) -> Scope {
+            state.hookForm
+        }
+        
+        func map(store: EnvironmentStore<AppState>) -> RootComponent.Props {
+            .init()
+        }
+        
+        func useHooks() -> [Hook<AppState>] {
+            Hook.hook(id: "RollbackHook") { state in
+                state.hookForm.triggerValue == "rollback"
+            } block: { store in
+                store.$state.hookForm.callbacksCount.wrappedValue = 0
+                store.$state.hookForm.triggerValue.wrappedValue = "reset"
+            }
+        }
+    }
+    
+    struct ConditionalHookContainer: Container {
+        typealias ContainerComponent = RootComponent
+        
+        func scope(for state: AppState) -> Scope {
+            state.hookForm
+        }
+        
+        func map(store: EnvironmentStore<AppState>) -> RootComponent.Props {
+            .init()
+        }
+        
+        func useHooks() -> [Hook<AppState>] {
+            Hook.hook(id: "ConditionalHook") { state in
+                state.hookForm.triggerValue == "trigger" && state.hookForm.callbacksCount % 2 == 0
+            } block: { store in
+                store.$state.hookForm.callbacksCount.wrappedValue += 1
+            }
+        }
+    }
+    
     struct RootContainer: Container {
         typealias ContainerComponent = RootComponent
 

--- a/Tests/SwiftUI-UDF-Tests/ContainerHookTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/ContainerHookTests.swift
@@ -147,6 +147,30 @@ final class ContainerHookTests: XCTestCase {
         await fulfill(description: "waiting for hook execution", sleep: 0.2)
         XCTAssertEqual(store.state.hookForm.triggerValue, "1", "One-time hook should not fire again in new container")
     }
+    
+    func test_HookFiresWhenConditionAlreadyTrueOnContainerAppear() async throws {
+        let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
+        
+        // Set the trigger value BEFORE creating the container
+        // This simulates the scenario where the condition is already true
+        store.$state.hookForm.triggerValue.wrappedValue = "1"
+        
+        await fulfill(description: "waiting for settings initial value", sleep: 1)
+        
+        XCTAssertEqual(store.state.hookForm.triggerValue, "1")
+        
+        // Now create the container - the hook condition is already satisfied
+        let rootContainer = await RootContainer()
+        let window = await PlatformWindow.render(container: rootContainer)
+        
+        await window.redraw()
+        await fulfill(description: "waiting for hook execution", sleep: 1)
+        
+        // The hook should have fired even though the condition was already true
+        // when the container appeared, changing "1" to "2"
+        XCTAssertEqual(store.state.hookForm.triggerValue, "2", 
+                       "Hook should fire at least once even if condition was already true when container appeared")
+    }
 }
 
 // MARK: - RootContainer

--- a/UDF/View/Container/ContainerHooks.swift
+++ b/UDF/View/Container/ContainerHooks.swift
@@ -66,6 +66,11 @@ final class ContainerHooks<State: AppReducer> {
         self.subscriptionKey = store.add { [weak self] oldState, newState, _ in
             self?.checkHooks(oldState: .init(oldState), newState: .init(newState))
         }
+        
+        // Trigger initial hook check to ensure hooks fire at least once
+        DispatchQueue.main.async { [weak self] in
+            self?.checkHooks(oldState: .init(store.state), newState: .init(store.state))
+        }
     }
 
     /// Creates hooks by building them from the provided closure and storing them in a dictionary.
@@ -80,7 +85,8 @@ final class ContainerHooks<State: AppReducer> {
     ///   - newState: The current state wrapped in a `Box`.
     private func checkHooks(oldState: Box<State>, newState: Box<State>) {
         for (key, hook) in hooks {
-            if hook.condition(newState.value), !hook.condition(oldState.value), let store {
+            // Fire hook if condition is true and (first check or condition changed from false to true)
+            if hook.condition(newState.value), (oldState.value == newState.value || !hook.condition(oldState.value)), let store {
                 hook.block(store)
 
                 switch hook.type {

--- a/UDF/View/Container/ContainerHooks.swift
+++ b/UDF/View/Container/ContainerHooks.swift
@@ -66,16 +66,14 @@ final class ContainerHooks<State: AppReducer> {
         self.subscriptionKey = store.add { [weak self] oldState, newState, _ in
             self?.checkHooks(oldState: .init(oldState), newState: .init(newState))
         }
-        
-        // Trigger initial hook check to ensure hooks fire at least once
-        DispatchQueue.main.async { [weak self] in
-            self?.checkHooks(oldState: .init(store.state), newState: .init(store.state))
-        }
     }
 
     /// Creates hooks by building them from the provided closure and storing them in a dictionary.
     func createHooks() {
         self.hooks = Dictionary(uniqueKeysWithValues: buildHooks().map { ($0.id, $0) })
+        
+        // Trigger initial hook check to ensure hooks fire at least once
+        checkInitialHooks()
     }
 
     /// Checks each hook's condition against the old and new state, triggering the hook if necessary.
@@ -84,18 +82,47 @@ final class ContainerHooks<State: AppReducer> {
     ///   - oldState: The previous state wrapped in a `Box`.
     ///   - newState: The current state wrapped in a `Box`.
     private func checkHooks(oldState: Box<State>, newState: Box<State>) {
+        var hooksToRemove: [AnyHashable] = []
+        
         for (key, hook) in hooks {
-            // Fire hook if condition is true and (first check or condition changed from false to true)
-            if hook.condition(newState.value), (oldState.value == newState.value || !hook.condition(oldState.value)), let store {
+            if hook.condition(newState.value), !hook.condition(oldState.value), let store {
                 hook.block(store)
 
                 switch hook.type {
                 case .oneTime:
-                    removeHook(by: key)
+                    hooksToRemove.append(key)
                 case .default:
                     break
                 }
             }
+        }
+        
+        for key in hooksToRemove {
+            removeHook(by: key)
+        }
+    }
+    
+    /// Checks hooks on initial container appearance, firing hooks if their condition is already true.
+    private func checkInitialHooks() {
+        guard let store = store else { return }
+        let currentState = Box(store.state)
+        var hooksToRemove: [AnyHashable] = []
+        
+        for (key, hook) in hooks {
+            if hook.condition(currentState.value) {
+                hook.block(store)
+                
+                switch hook.type {
+                case .oneTime:
+                    hooksToRemove.append(key)
+                case .default:
+                    break
+                }
+            }
+        }
+        
+        for key in hooksToRemove {
+            removeHook(by: key)
         }
     }
 


### PR DESCRIPTION
Hooks now fire on initial check if condition is met, not just on state transitions from false to true