### PR TITLE
Fix: Dialog toasts issues

### DIFF
--- a/UDF/View/Dialog/Configurations/ToastConfiguration.swift
+++ b/UDF/View/Dialog/Configurations/ToastConfiguration.swift
@@ -95,7 +95,7 @@ public struct ToastConfiguration: Hashable, Sendable {
     ///
     /// Prevents toasts from becoming too wide on larger screens while ensuring
     /// they remain readable and visually balanced.
-    /// - Default: 600 points
+    /// - Default: .infinity
     public var maxWidth: CGFloat
     
     /// The horizontal padding around toast content within the screen bounds.
@@ -149,11 +149,8 @@ public struct ToastConfiguration: Hashable, Sendable {
         tapToDismiss: Bool = true,
         swipeToDismiss: Bool = true,
         animation: Animation = .spring(response: 0.3, dampingFraction: 0.6, blendDuration: 0),
-        transition: AnyTransition = .asymmetric(
-            insertion: .move(edge: .top).combined(with: .opacity),
-            removal: .move(edge: .top).combined(with: .opacity)
-        ),
-        maxWidth: CGFloat = 600,
+        transition: AnyTransition? = nil,
+        maxWidth: CGFloat = .infinity,
         horizontalPadding: CGFloat = 16,
         textAlignment: HorizontalAlignment = .leading
     ) {
@@ -164,7 +161,28 @@ public struct ToastConfiguration: Hashable, Sendable {
         self.tapToDismiss = tapToDismiss
         self.swipeToDismiss = swipeToDismiss
         self.animation = animation
-        self.transition = transition
+        
+        // Set position-appropriate transition if none provided
+        if let customTransition = transition {
+            self.transition = customTransition
+        } else {
+            // Use position-based transition
+            switch position {
+            case .top:
+                self.transition = .asymmetric(
+                    insertion: .move(edge: .top).combined(with: .opacity),
+                    removal: .move(edge: .top).combined(with: .opacity)
+                )
+            case .bottom:
+                self.transition = .asymmetric(
+                    insertion: .move(edge: .bottom).combined(with: .opacity),
+                    removal: .move(edge: .bottom).combined(with: .opacity)
+                )
+            case .center, .custom:
+                self.transition = .opacity.combined(with: .scale(scale: 0.9))
+            }
+        }
+        
         self.maxWidth = maxWidth
         self.horizontalPadding = horizontalPadding
         self.textAlignment = textAlignment
@@ -211,25 +229,20 @@ public extension ToastConfiguration {
     /// 
     /// Uses bottom slide transition and positioning suitable for bottom toasts:
     /// - Bottom positioning
-    /// - Slide from bottom transition
+    /// - Slide from bottom transition (automatically set)
     /// - Other settings match default
     static let bottom = ToastConfiguration(
-        position: .bottom,
-        transition: .asymmetric(
-            insertion: .move(edge: .bottom).combined(with: .opacity),
-            removal: .move(edge: .bottom).combined(with: .opacity)
-        )
+        position: .bottom
     )
     
     /// Configuration optimized for center positioning.
     /// 
     /// Uses scale transition and center alignment suitable for center toasts:
     /// - Center positioning
-    /// - Scale transition with opacity
+    /// - Scale transition with opacity (automatically set)
     /// - Center text alignment
     static let center = ToastConfiguration(
         position: .center,
-        transition: .opacity.combined(with: .scale(scale: 0.9)),
         textAlignment: .center
     )
     

--- a/UDF/View/Dialog/Configurations/ToastQueueConfiguration.swift
+++ b/UDF/View/Dialog/Configurations/ToastQueueConfiguration.swift
@@ -167,7 +167,7 @@ public struct ToastQueueConfiguration: Hashable, Sendable {
         showQueuedToastsImmediately: Bool = true,
         stackSpacing: CGFloat = 8,
         maxStackOffset: CGFloat = 200,
-        queueAnimation: Animation = .spring(response: 0.3, dampingFraction: 0.7),
+        queueAnimation: Animation = .spring(response: 0.5, dampingFraction: 0.7),
         useStaggeredAnimations: Bool = true,
         staggerDelay: TimeInterval = 0.1
     ) {

--- a/UDF/View/Dialog/Core/DialogRegistration.swift
+++ b/UDF/View/Dialog/Core/DialogRegistration.swift
@@ -69,10 +69,13 @@ public enum DialogRegistry {
     /// ## Example:
     /// ```swift
     /// DialogRegistry.register(id: "deleteConfirmation") {
-    ///     .custom(content: DialogContent("Delete Item", message: "This cannot be undone") {
-    ///         DialogButton.destructive("Delete") { performDelete() }
-    ///         DialogButton.cancel("Cancel")
-    ///     })
+    ///     DialogCustomType.custom(
+    ///         content: DialogContent("Delete Item", message: "This cannot be undone") {
+    ///             DialogButton.destructive("Delete") { performDelete() }
+    ///             DialogButton.cancel("Cancel")
+    ///         },
+    ///         style: .alert
+    ///     )
     /// }
     /// ```
     public static func register<ID: Hashable & Sendable>(
@@ -211,6 +214,91 @@ public enum DialogRegistry {
                 let content = DialogContent(message)
                 return DialogCustomType.custom(content: content, style: style)
             }
+        }
+    }
+}
+
+// MARK: - ToastRegistry Extension
+
+/// Toast-specific registration extensions for `DialogRegistry`.
+///
+/// This extension provides convenient methods for registering toast dialogs
+/// with common configurations and patterns. Toasts are non-modal dialogs
+/// that appear as overlay notifications.
+public extension DialogRegistry {
+    
+    /// Registers a toast dialog with custom content and configuration.
+    ///
+    /// This method provides a convenient way to register toast dialogs with
+    /// rich content and custom styling. Unlike alerts, toasts support theming,
+    /// positioning, and non-modal presentation.
+    ///
+    /// - Parameters:
+    ///   - id: A unique identifier for the toast.
+    ///   - content: The dialog content with title, message, and actions.
+    ///   - configuration: Toast-specific configuration for styling and behavior.
+    ///
+    /// ## Example:
+    /// ```swift
+    /// DialogRegistry.registerToast(id: "uploadProgress") {
+    ///     DialogContent(
+    ///         title: "Uploading File",
+    ///         actions: {
+    ///             DialogButton.cancel("Cancel") { cancelUpload() }
+    ///         }
+    ///     )
+    /// } configuration: {
+    ///     ToastConfiguration(
+    ///         theme: .vibrant,
+    ///         position: .bottom,
+    ///         defaultDuration: 5.0
+    ///     )
+    /// }
+    /// ```
+    static func registerToast<ID: Hashable & Sendable>(
+        id: ID,
+        content: @escaping @Sendable () -> DialogContent<EmptyView, EmptyView>,
+        configuration: @escaping @Sendable () -> ToastConfiguration = { .default }
+    ) {
+        register(id: id) {
+            DialogCustomType.custom(
+                content: content(),
+                style: .toast(configuration())
+            )
+        }
+    }
+    
+    /// Registers a toast with custom SwiftUI content.
+    ///
+    /// This method allows registration of toasts with completely custom SwiftUI views,
+    /// providing maximum flexibility for rich notifications, progress indicators,
+    /// and interactive toast experiences.
+    ///
+    /// - Parameters:
+    ///   - id: A unique identifier for the toast.
+    ///   - title: The toast title.
+    ///   - customView: A closure returning the custom SwiftUI content.
+    ///   - configuration: Toast configuration for styling and behavior.
+    ///
+    /// ## Example:
+    /// ```swift
+    /// DialogRegistry.registerCustomToast(id: "downloadProgress", title: "Downloading") {
+    ///     VStack(spacing: 8) {
+    ///         ProgressView(value: downloadProgress)
+    ///         Text("\(Int(downloadProgress * 100))% complete")
+    ///             .font(.caption)
+    ///     }
+    /// }
+    /// ```
+    static func registerCustomToast<ID: Hashable & Sendable, CustomContent: View>(
+        id: ID,
+        title: String,
+        customContent: @escaping @Sendable () -> CustomContent,
+        configuration: @escaping @Sendable () -> ToastConfiguration = { .default }
+    ) {
+        register(id: id) {
+            let content = DialogContent(title: title, customContent: customContent)
+            return DialogCustomType.custom(content: content, style: .toast(configuration()))
         }
     }
 }

--- a/UDF/View/Dialog/Views/ToastContainer.swift
+++ b/UDF/View/Dialog/Views/ToastContainer.swift
@@ -63,38 +63,31 @@ struct ToastContainer: View {
     var body: some View {
         GeometryReader { geometry in
             ZStack {
-                ForEach([ToastPosition.top, .center, .bottom], id: \.self) { position in
-                    let toastsForPosition = queueManager.visibleToasts.filter { displayInfo in
-                        let config = effectiveConfiguration(for: displayInfo)
-                        return config.position == position
-                    }
-
-                    if !toastsForPosition.isEmpty {
-                        VStack(spacing: queueManager.configuration.stackSpacing) {
-                            ForEach(position == .bottom ? toastsForPosition.reversed() : toastsForPosition, id: \.self) { displayInfo in
-                                let configuration = effectiveConfiguration(for: displayInfo)
-                                let toast: any DialogTypeProtocol = displayInfo.toast
-
-                                ToastView(
-                                    toast: toast,
-                                    configuration: configuration,
-                                    onDismiss: {
-                                        queueManager.dismiss(displayInfo.id)
-                                        onDismiss(displayInfo.id)
-                                    }
-                                )
-                                .padding(.horizontal)
-                                .transition(configuration.transition)
-                                .id(displayInfo.id)
-                                .allowsHitTesting(configuration.tapToDismiss || configuration.swipeToDismiss)
-                            }
+                Color.clear
+                    .ignoresSafeArea()
+                    .allowsHitTesting(false)
+                
+                ForEach(queueManager.visibleToasts, id: \.self) { displayInfo in
+                    let configuration = effectiveConfiguration(for: displayInfo)
+                    let toast: any DialogTypeProtocol = displayInfo.toast
+                    
+                    ToastView(
+                        toast: toast,
+                        configuration: configuration,
+                        onDismiss: {
+                            queueManager.dismiss(displayInfo.id)
+                            onDismiss(displayInfo.id)
                         }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment(for: position))
-                        .offset(offset(for: position, in: geometry))
-                    }
+                    )
+                    .transition(configuration.transition)
+                    .id(displayInfo.id)
+                    .allowsHitTesting(true)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment(for: configuration.position))
+                    .offset(offset(for: configuration.position, in: geometry))
+                    .offset(y: stackOffset(for: displayInfo))
                 }
             }
-            .animation(.default, value: queueManager.visibleToasts)
+            .animation(queueManager.configuration.queueAnimation, value: queueManager.visibleToasts)
         }
         .onAppear {
             if let initialToasts = _initialToasts {

--- a/UDF/View/Dialog/Views/ToastView.swift
+++ b/UDF/View/Dialog/Views/ToastView.swift
@@ -72,11 +72,6 @@ struct ToastView: View {
         self.content = toast.getCustomContentView
     }
 
-    /// Current drag offset for swipe-to-dismiss gesture tracking.
-    @State private var dragOffset: CGSize = .zero
-    
-    /// Indicates whether the user is currently dragging the toast.
-    @GestureState private var isDragging: Bool = false
     
     // MARK: - Computed Properties
     
@@ -119,7 +114,6 @@ struct ToastView: View {
                 standardToastContent
             }
         }
-        .offset(dragOffset)
         .gesture(dismissGestures)
         .onTapGesture {
             if configuration.tapToDismiss {
@@ -165,45 +159,44 @@ private extension ToastView {
             theme.colorStyle(for: toast.category).background()
                 .cornerRadius(theme.cornerRadius)
         )
+        .padding(.horizontal, configuration.horizontalPadding)
         .applyShadow(theme.shadow)
     }
 }
 
 // MARK: - Gesture Handling
 private extension ToastView {
-    /// Drag gesture for swipe-to-dismiss functionality.
+    /// Swipe gesture for swipe-to-dismiss functionality.
     ///
-    /// Implements intuitive swipe-to-dismiss behavior with threshold-based
-    /// dismissal and spring-back animation for incomplete swipes.
+    /// Implements intuitive swipe-to-dismiss behavior based on swipe velocity
+    /// rather than drag distance, providing immediate dismissal for fast swipes.
     ///
     /// ## Behavior:
-    /// 1. **Active Dragging**: Toast follows finger movement with real-time offset
-    /// 2. **Threshold Check**: Dismisses if swipe distance exceeds 100 points
-    /// 3. **Spring Back**: Returns to original position for insufficient swipes
-    /// 4. **Conditional**: Only active if `swipeToDismiss` is enabled and toast is dismissible
+    /// 1. **Velocity Detection**: Detects fast vertical swipes (up/down)
+    /// 2. **Immediate Dismissal**: Dismisses instantly when swipe velocity threshold is met
+    /// 3. **No Visual Dragging**: Toast stays in place during swipe detection
+    /// 4. **Vertical Only**: Only responds to up/down swipes for intuitive toast dismissal
     ///
     /// ## Gesture Parameters:
-    /// - **Threshold**: 100 points in any direction
-    /// - **Spring Animation**: Natural bounce-back for incomplete gestures
-    /// - **Multi-directional**: Supports horizontal and vertical swipes
+    /// - **Velocity Threshold**: 300 points/second in vertical direction
+    /// - **Minimum Distance**: 50 points to avoid accidental dismissals
+    /// - **Direction**: Vertical swipes only (up or down)
     var dismissGestures: some Gesture {
         DragGesture()
-            .updating($isDragging) { _, state, _ in
-                state = true
-            }
-            .onChanged { value in
-                if configuration.swipeToDismiss {
-                    dragOffset = value.translation
-                }
-            }
             .onEnded { value in
-                let threshold: CGFloat = 100
-                if abs(value.translation.width) > threshold || abs(value.translation.height) > threshold {
+                guard configuration.swipeToDismiss else { return }
+                
+                // Calculate swipe velocity (points per second)
+                let verticalVelocity = abs(value.velocity.height)
+                let horizontalVelocity = abs(value.velocity.width)
+                
+                // Check if it's a vertical swipe with sufficient velocity and distance
+                let isVerticalSwipe = verticalVelocity > horizontalVelocity
+                let hasMinimumDistance = abs(value.translation.height) > 50
+                let hasMinimumVelocity = verticalVelocity > 300
+                
+                if isVerticalSwipe && hasMinimumDistance && hasMinimumVelocity {
                     onDismiss()
-                } else {
-                    withAnimation(.spring()) {
-                        dragOffset = .zero
-                    }
                 }
             }
     }


### PR DESCRIPTION
### Description
This merge request improves the configuration and management of toast notifications in the UI dialog framework. Several changes provide greater flexibility and smarter defaults for toast transitions and appearance, optimize gesture-driven dismissals for toasts, and add more convenient registration methods for custom and standard toast dialogs. The changes ensure toast behaviors are more intuitive and easily configurable by developers, especially regarding animation, width management, and user interactions.

### Changes Made

- **ToastConfiguration Enhancements:**
  - `maxWidth` default changed from `.600` to `.infinity`, making toasts naturally adapt to the available width unless constrained.
  - The `transition` property is now optional. If not set, it is automatically determined by the toast's `position` (e.g., slide from top, bottom, or scale for center/custom positions).
  - Simplified the initializer and default configurations (`bottom`, `center`) by removing explicit transition assignment—transitions are now inferred from the position.

- **Queue Animation Adjustment:**
  - The default `queueAnimation` for stacked toasts changed from `.spring(response: 0.3, ...)` to `.spring(response: 0.5, ...)` for smoother animation.

- **DialogRegistry Enhancements for Toasts:**
  - Added `registerToast` and `registerCustomToast` methods to conveniently create and register toasts, supporting both standard `DialogContent` and arbitrary SwiftUI view-based toast contents.
  - Improved documentation and usage examples for these new registration APIs.

- **ToastContainer Refactor:**
  - Refactored the ZStack toast layout to iterate over all visible toasts in a flat list (rather than grouping by position), aligning their display, offset, and animation individually.
  - Each toast uses its own configuration for alignment, offset, and animation parameters, rather than grouping by position.

- **ToastView Gesture Handling Update:**
  - Replaced the drag-distance-based swipe-to-dismiss mechanic with a velocity-sensitive gesture:
    - Toasts are now dismissed only if a swift, vertical swipe (up or down) is detected (velocity over 300 pts/sec and translation > 50 pts), improving the gesture's reliability and responsiveness.
    - The visual dragging offset and "snap back" animation for incomplete gestures have been removed; toast visuals remain stationary until dismissal.
    - This results in a crisper and more intentional swipe-to-dismiss behavior.
  - Removed obsolete state and gesture variables relating to drag offset and active dragging state.

These changes collectively increase flexibility, create a more natural and modern toast interaction experience, and make the dialog/toast API easier to use and extend.

### ClickUp task
https://app.clickup.com/t/8699xmut5