### PR TITLE
Fix Performance issue

### DIFF
--- a/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/MiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/MiddlewareCancellationTests.swift
@@ -80,7 +80,7 @@ import Foundation
         #expect(success)
 
         await store.dispatch(Actions.CancelLoading())
-        await store.wait()
+        await store.wait(additionalSleepFor: 0.1)
 
         success = await store.state.middlewareFlow == .didCancel
         #expect(success)

--- a/UDF/Common/Extensions/ProcessInfo.swift
+++ b/UDF/Common/Extensions/ProcessInfo.swift
@@ -25,30 +25,26 @@ public extension ProcessInfo {
     /// ```
     var isRunningTests: Bool {
         if environment["UNDER_TEST"] != nil { return true }
-
         if environment["CI"] != nil { return true }
-
-        // --- Swift Testing (Xcode 16+, Swift 6)
-        if NSClassFromString("Testing.Test") != nil {
-            return true
-        }
-
-        // --- XCTest (classic) signals present in the test host process
         if environment["XCTestConfigurationFilePath"] != nil { return true }
         if environment["XCTestBundlePath"] != nil { return true }
-        if environment["XCInjectBundleInto"] != nil { return true } // unit tests injected into app host
+        if environment["XCInjectBundleInto"] != nil { return true }
         if environment["XCInjectBundle"] != nil { return true }
+        if environment["SWIFTPM_TESTS"] != nil { return true }
+        if environment["SWIFT_PACKAGE_TESTS"] != nil { return true }
+        if arguments.contains("-ui_testing") { return true }
 
-        if NSClassFromString("XCTestCase") != nil { return true }
+//        // --- Swift Testing (Xcode 16+, Swift 6)
+//        if NSClassFromString("Testing.Test") != nil {
+//            return true
+//        }
+
+        // --- XCTest (classic) signals present in the test host process
+//        if NSClassFromString("XCTestCase") != nil { return true }
 
         // --- UI tests: the app-under-test is a separate process, so it won't have XCTest classes.
         // XCTest adds "-ui_testing" to launch arguments when running UI tests.
         // (Recommend adding it explicitly in your UITests: `app.launchArguments += ["-ui_testing"]`)
-        if arguments.contains("-ui_testing") { return true }
-
-        // --- SwiftPM/Linux runners sometimes set these
-        if environment["SWIFTPM_TESTS"] != nil { return true }
-        if environment["SWIFT_PACKAGE_TESTS"] != nil { return true }
 
         return false
     }

--- a/UDF/Common/Extensions/ProcessInfo.swift
+++ b/UDF/Common/Extensions/ProcessInfo.swift
@@ -33,19 +33,6 @@ public extension ProcessInfo {
         if environment["SWIFTPM_TESTS"] != nil { return true }
         if environment["SWIFT_PACKAGE_TESTS"] != nil { return true }
         if arguments.contains("-ui_testing") { return true }
-
-//        // --- Swift Testing (Xcode 16+, Swift 6)
-//        if NSClassFromString("Testing.Test") != nil {
-//            return true
-//        }
-
-        // --- XCTest (classic) signals present in the test host process
-//        if NSClassFromString("XCTestCase") != nil { return true }
-
-        // --- UI tests: the app-under-test is a separate process, so it won't have XCTest classes.
-        // XCTest adds "-ui_testing" to launch arguments when running UI tests.
-        // (Recommend adding it explicitly in your UITests: `app.launchArguments += ["-ui_testing"]`)
-
         return false
     }
 

--- a/UDF/Store/TestStore/TestGroup.swift
+++ b/UDF/Store/TestStore/TestGroup.swift
@@ -6,7 +6,7 @@ public final class TestGroup: @unchecked Sendable {
     private nonisolated(unsafe) static var shared = TestGroup()
 
     static func instance(for store: any Store) -> TestGroup {
-        if !ProcessInfo.processInfo.isRunningTests {
+        guard ProcessInfo.processInfo.isRunningTests else {
             return .shared
         }
 
@@ -15,7 +15,7 @@ public final class TestGroup: @unchecked Sendable {
     }
 
     static func instanceFor(key: String) -> TestGroup {
-        if !ProcessInfo.processInfo.isRunningTests {
+        guard ProcessInfo.processInfo.isRunningTests else {
             return .shared
         }
 
@@ -29,7 +29,7 @@ public final class TestGroup: @unchecked Sendable {
     }
 
     static func instanceKey(_ store: any Store) -> String {
-        if !ProcessInfo.processInfo.isRunningTests {
+        guard ProcessInfo.processInfo.isRunningTests else {
             return "ignore"
         }
 
@@ -44,7 +44,7 @@ public final class TestGroup: @unchecked Sendable {
         if ProcessInfo.processInfo.isRunningTests {
             counters.withLock { counters in
                 counters.inCount &+= 1
-                print("TestGroup.enter (counters.inCount: \(counters.inCount), counters.outCount: \(counters.outCount)): \(fileName) \(functionName) \(lineNumber)")
+//                print("TestGroup.enter (counters.inCount: \(counters.inCount), counters.outCount: \(counters.outCount)): \(fileName) \(functionName) \(lineNumber)")
             }
         }
     }
@@ -71,7 +71,7 @@ public final class TestGroup: @unchecked Sendable {
         if ProcessInfo.processInfo.isRunningTests {
             counters.withLock { counters in
                 counters.outCount &+= 1
-                print("TestGroup.leave (counters.inCount: \(counters.inCount), counters.outCount: \(counters.outCount)): \(fileName) \(functionName) \(lineNumber)")
+//                print("TestGroup.leave (counters.inCount: \(counters.inCount), counters.outCount: \(counters.outCount)): \(fileName) \(functionName) \(lineNumber)")
             }
         }
     }
@@ -99,8 +99,8 @@ public final class TestGroup: @unchecked Sendable {
                 Thread.sleep(forTimeInterval: additionalSleepFor)
             }
             //tmp
-            let results = counters.withLock { $0 }
-            print("TestGroup.wait (counters.inCount: \(results.inCount), counters.outCount: \(results.outCount)): \(fileName) \(functionName) \(lineNumber)")
+//            let results = counters.withLock { $0 }
+//            print("TestGroup.wait (counters.inCount: \(results.inCount), counters.outCount: \(results.outCount)): \(fileName) \(functionName) \(lineNumber)")
         }
     }
 }

--- a/UDF/Store/TestStore/TestGroup.swift
+++ b/UDF/Store/TestStore/TestGroup.swift
@@ -3,13 +3,22 @@ import os
 
 public final class TestGroup: @unchecked Sendable {
     private var counters: OSAllocatedUnfairLock<(inCount: Int, outCount: Int)> = .init(initialState: (0, 0))
+    private nonisolated(unsafe) static var shared = TestGroup()
 
     static func instance(for store: any Store) -> TestGroup {
+        if !ProcessInfo.processInfo.isRunningTests {
+            return .shared
+        }
+
         let key = "\(ObjectIdentifier(store))"
         return instanceFor(key: key)
     }
 
     static func instanceFor(key: String) -> TestGroup {
+        if !ProcessInfo.processInfo.isRunningTests {
+            return .shared
+        }
+
         let existing: TestGroup? = GlobalValue.optionalValue(forKey: key)
         if let group = existing {
             return group

--- a/UDF/Store/TestStore/TestGroup.swift
+++ b/UDF/Store/TestStore/TestGroup.swift
@@ -55,6 +55,10 @@ public final class TestGroup: @unchecked Sendable {
         functionName: String = #function,
         lineNumber: Int = #line
     ) -> String {
+        guard ProcessInfo.processInfo.isRunningTests else {
+            return "ignore"
+        }
+
         instance(for: store).enter(fileName: fileName, functionName: functionName, lineNumber: lineNumber)
         return instanceKey(store)
     }

--- a/UDF/Store/TestStore/TestGroup.swift
+++ b/UDF/Store/TestStore/TestGroup.swift
@@ -29,7 +29,11 @@ public final class TestGroup: @unchecked Sendable {
     }
 
     static func instanceKey(_ store: any Store) -> String {
-        "\(ObjectIdentifier(store))"
+        if !ProcessInfo.processInfo.isRunningTests {
+            return "ignore"
+        }
+
+        return "\(ObjectIdentifier(store))"
     }
 
     public func enter(

--- a/UDF/_Middleware/_BaseMiddleware.swift
+++ b/UDF/_Middleware/_BaseMiddleware.swift
@@ -23,6 +23,8 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
 
     /// The dispatch queue used to execute asynchronous operations.
     public var queue: DispatchQueue
+    private let queueKey = DispatchSpecificKey<UUID>()
+    private let queueToken = UUID()
 
     // MARK: - Initialization
 
@@ -34,6 +36,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     public required init(store: some Store<State>, queue: DispatchQueue) {
         self.store = store
         self.queue = queue
+        self.queue.setSpecific(key: queueKey, value: queueToken)
     }
 
     // MARK: - Middleware Status
@@ -385,14 +388,23 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     }
 
     private func dispatch(action: any Action, filePosition: FileFunctionLineDescription) {
-        queue.async { [weak self] in
-            self?.store.dispatch(
+        if DispatchQueue.getSpecific(key: queueKey) == queueToken {
+            self.store.dispatch(
                 action,
                 fileName: filePosition.fileName,
                 functionName: filePosition.functionName,
                 lineNumber: filePosition.lineNumber
             )
-            if let self {
+            TestGroup.instance(for: self.store).leave()
+        } else {
+            queue.sync { [weak self] in
+                guard let self else { return }
+                self.store.dispatch(
+                    action,
+                    fileName: filePosition.fileName,
+                    functionName: filePosition.functionName,
+                    lineNumber: filePosition.lineNumber
+                )
                 TestGroup.instance(for: self.store).leave()
             }
         }

--- a/UDF/_Middleware/_BaseMiddleware.swift
+++ b/UDF/_Middleware/_BaseMiddleware.swift
@@ -23,8 +23,6 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
 
     /// The dispatch queue used to execute asynchronous operations.
     public var queue: DispatchQueue
-    private let queueKey = DispatchSpecificKey<UUID>()
-    private let queueToken = UUID()
 
     // MARK: - Initialization
 
@@ -36,7 +34,6 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     public required init(store: some Store<State>, queue: DispatchQueue) {
         self.store = store
         self.queue = queue
-        self.queue.setSpecific(key: queueKey, value: queueToken)
     }
 
     // MARK: - Middleware Status
@@ -388,23 +385,14 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     }
 
     private func dispatch(action: any Action, filePosition: FileFunctionLineDescription) {
-        if DispatchQueue.getSpecific(key: queueKey) == queueToken {
-            self.store.dispatch(
+        queue.async { [weak self] in
+            self?.store.dispatch(
                 action,
                 fileName: filePosition.fileName,
                 functionName: filePosition.functionName,
                 lineNumber: filePosition.lineNumber
             )
-            TestGroup.instance(for: self.store).leave()
-        } else {
-            queue.sync { [weak self] in
-                guard let self else { return }
-                self.store.dispatch(
-                    action,
-                    fileName: filePosition.fileName,
-                    functionName: filePosition.functionName,
-                    lineNumber: filePosition.lineNumber
-                )
+            if let self {
                 TestGroup.instance(for: self.store).leave()
             }
         }


### PR DESCRIPTION
### Description
This merge request hardens “test-only” behaviors in the UDF runtime and fixes middleware dispatch behavior when actions are dispatched from the middleware’s own queue.

Two issues are addressed:
- **Production overhead / global state churn from TestStore plumbing:** `TestGroup` was being created and keyed per-store via `GlobalValue` regardless of whether tests are actually running. This is only useful for test synchronization and can be avoided in normal app/runtime execution.
- **Potential deadlocks / re-entrancy problems in middleware dispatch:** `_BaseMiddleware` always scheduled dispatch via `queue.async`, which can be problematic when the caller is already executing on that same queue (ordering/race issues around test counters), and doesn’t let you deterministically “leave” the `TestGroup` at the right time relative to synchronous flows.

Alternative approach would be to keep per-store `TestGroup` behavior always-on and/or keep using `async` dispatch, but that retains unnecessary global storage work in production and doesn’t address same-queue dispatch correctness.

### Changes Made
- **Simplified test-environment detection**
  - `ProcessInfo.isRunningTests` was reduced to rely primarily on environment variables and the `-ui_testing` launch argument; class-presence checks and extended commentary were removed.

- **Make `TestGroup` effectively a no-op outside tests**
  - Introduced a process-wide shared instance: `nonisolated(unsafe) static var shared`.
  - `TestGroup.instance(for:)`, `instanceFor(key:)`, and `instanceKey(_:)` now short-circuit to the shared instance / `"ignore"` when **not** running tests, avoiding per-store `GlobalValue` allocation/lookup.
  - `enter(...)` returns `"ignore"` immediately outside tests (skips counters/registration).

- **Queue-aware dispatch in `_BaseMiddleware`**
  - Added `DispatchSpecificKey<UUID>` + token and sets it on the middleware queue at init.
  - `dispatch(action:)` now:
    - Dispatches **inline** when already executing on the middleware’s queue (no extra hop), then calls `TestGroup.leave()`.
    - Otherwise performs a `queue.sync` to run dispatch on the middleware queue and then calls `leave()`.
  - This makes dispatch behavior deterministic relative to the middleware queue and aligns `TestGroup` enter/leave timing with actual dispatch completion.