### PR TITLE
DialogContent extra inits

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/Dialog/DialogActionsBuilderTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/DialogActionsBuilderTests.swift
@@ -6,7 +6,7 @@ import SwiftUI
 
     // MARK: - Basic Builder Tests
     @Test func whenVoid_ActionGroupShouldBeEmpty() {
-        let content = DialogContent(title: { "" }, message: "") {
+        let content = DialogContent(title: "", message: "") {
             ()
         }
 

--- a/Tests/SwiftUI-UDF-Tests/Dialog/DialogActionsBuilderTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/DialogActionsBuilderTests.swift
@@ -6,7 +6,7 @@ import SwiftUI
 
     // MARK: - Basic Builder Tests
     @Test func whenVoid_ActionGroupShouldBeEmpty() {
-        let content = DialogContent(title: "", message: "") {
+        let content = DialogContent(title: { "" }, message: "") {
             ()
         }
 

--- a/UDF/View/AlertBuilder/AlertBuilder.swift
+++ b/UDF/View/AlertBuilder/AlertBuilder.swift
@@ -36,13 +36,13 @@ public enum AlertBuilder {
         
         /// Enum representing the different types of alerts.
         enum AlertType {
-            case validationError(text: () -> String)
-            case success(text: () -> String)
-            case failure(text: () -> String)
-            case message(text: () -> String)
-            case messageTitle(title: () -> String, message: () -> String)
-            
-            case customActions(title: () -> String, text: () -> String, actions: @Sendable () -> [any AlertAction])
+            case validationError(text: @Sendable () -> String)
+            case success(text: @Sendable () -> String)
+            case failure(text: @Sendable () -> String)
+            case message(text: @Sendable () -> String)
+            case messageTitle(title: @autoclosure @Sendable () -> String, message: @Sendable () -> String)
+
+            case customActions(title: @Sendable () -> String, text: @Sendable () -> String, actions: @Sendable () -> [any AlertAction])
         }
         
         // MARK: Initializers
@@ -52,7 +52,7 @@ public enum AlertBuilder {
         }
         
         /// Initializes a validation error alert style with a closure providing the text.
-        public init(validationError text: @escaping () -> String) {
+        public init(validationError text: @Sendable @escaping () -> String) {
             id = UUID()
             type = .validationError(text: text)
         }
@@ -63,7 +63,7 @@ public enum AlertBuilder {
         }
         
         /// Initializes a failure alert style with a closure providing the text.
-        public init(failure text: @escaping () -> String) {
+        public init(failure text: @Sendable @escaping () -> String) {
             id = UUID()
             type = .failure(text: text)
         }
@@ -74,7 +74,7 @@ public enum AlertBuilder {
         }
         
         /// Initializes a success alert style with a closure providing the text.
-        public init(success text: @escaping () -> String) {
+        public init(success text: @Sendable @escaping () -> String) {
             id = UUID()
             type = .success(text: text)
         }
@@ -85,20 +85,20 @@ public enum AlertBuilder {
         }
         
         /// Initializes a message alert style with a closure providing the text.
-        public init(message text: @escaping () -> String) {
+        public init(message text: @Sendable @escaping () -> String) {
             id = UUID()
             type = .message(text: text)
         }
         
         /// Initializes an alert style with a title and message.
         public init(title: String, message: String) {
-            self.init(title: { title }, message: { message })
+            self.init(title: { title }(), message: { message }())
         }
         
         /// Initializes an alert style with closures for title and message.
-        public init(title: @escaping () -> String, message: @escaping () -> String) {
+        public init(title: @autoclosure @Sendable @escaping () -> String, message: @Sendable @escaping () -> String) {
             id = UUID()
-            type = .messageTitle(title: title, message: message)
+            type = .messageTitle(title: title(), message: message)
         }
         
         /// Initializes a custom alert style with a title, text, and custom actions.
@@ -108,8 +108,8 @@ public enum AlertBuilder {
         
         /// Initializes a custom alert style with closures for title, text, and actions.
         public init(
-            title: @escaping () -> String,
-            text: @escaping () -> String,
+            title: @Sendable @escaping () -> String,
+            text: @Sendable @escaping () -> String,
             @DialogActionsBuilder actions: @Sendable @escaping () -> [any AlertAction]
         ) {
             id = UUID()

--- a/UDF/View/Dialog/Content/DialogContent.swift
+++ b/UDF/View/Dialog/Content/DialogContent.swift
@@ -101,182 +101,607 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
     }
     
     // MARK: - Initializers
-    /// Creates dialog content with a title only.
+    /// Creates dialog content with a title only (plain value).
     ///
-    /// - Parameter title: The title of the dialog.
+    /// Use this overload when passing a literal or plain String expression for the title.
+    /// For a computed title, use the closure-based overload.
+    /// - Parameter title: The dialog title evaluated via @autoclosure.
     public init(title: @autoclosure @escaping @Sendable () -> String) where Icon == EmptyView, CustomContent == EmptyView {
-        self.title = title
-        self.message = { nil }
-        self.actions = []
-        self.customContentView = nil
-        self.iconView = nil
+        self.init(title: title)
     }
     
-    /// Creates dialog content with a title and message.
+    /// Creates dialog content with a title only (closure-based).
     ///
+    /// Use this overload when the title should be computed lazily at presentation time.
+    /// - Parameter title: A closure that returns the dialog title.
+    public init(title: @escaping @Sendable () -> String) where Icon == EmptyView, CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: { nil },
+            actions: [],
+            iconBuilder: nil,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title and message (plain values).
+    ///
+    /// Use this overload when passing literal/plain values. For computed values,
+    /// use one of the closure-based overloads.
     /// - Parameters:
-    ///   - title: The title of the dialog.
-    ///   - message: An optional message for additional details.
+    ///   - title: The dialog title evaluated via @autoclosure.
+    ///   - message: The optional dialog message evaluated via @autoclosure.
     public init(title: @autoclosure @escaping @Sendable () -> String, message: @autoclosure @escaping @Sendable () -> String?) where Icon == EmptyView, CustomContent == EmptyView {
-        self.title = title
-        self.message = message
-        self.actions = []
-        self.customContentView = nil
-        self.iconView = nil
+        self.init(title: title, message: message)
     }
     
-    /// Creates dialog content with just a message.
+    /// Creates dialog content with a title (closure-based) and message (plain value).
     ///
-    /// This is a convenience initializer for simple dialogs that only need
-    /// to display a message without additional content or actions.
+    /// - Parameters:
+    ///   - title: A closure that returns the dialog title.
+    ///   - message: The optional dialog message evaluated via @autoclosure.
+    public init(title: @escaping @Sendable () -> String, message: @autoclosure @escaping @Sendable () -> String?) where Icon == EmptyView, CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: message,
+            actions: [],
+            iconBuilder: nil,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title (plain value) and message (closure-based).
     ///
-    /// - Parameter message: The message to display.
+    /// - Parameters:
+    ///   - title: The dialog title evaluated via @autoclosure.
+    ///   - message: A closure that returns the optional dialog message.
+    public init(title: @autoclosure @escaping @Sendable () -> String, message: @escaping @Sendable () -> String?) where Icon == EmptyView, CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: message,
+            actions: [],
+            iconBuilder: nil,
+            customContentBuilder: nil
+        )
+    }
+
+    /// Creates dialog content with a title and message (both closure-based).
+    ///
+    /// - Parameters:
+    ///   - title: A closure that returns the dialog title.
+    ///   - message: A closure that returns the optional dialog message.
+    public init(title: @escaping @Sendable () -> String, message: @escaping @Sendable () -> String?) where Icon == EmptyView, CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: message,
+            actions: [],
+            iconBuilder: nil,
+            customContentBuilder: nil
+        )
+    }
+
+    /// Creates dialog content with just a message (plain value).
+    ///
+    /// The title is empty by default.
+    /// - Parameter message: The dialog message evaluated via @autoclosure.
     public init(_ message: @autoclosure @escaping @Sendable () -> String) where Icon == EmptyView, CustomContent == EmptyView {
-        self.title = { "" }
-        self.message = message
-        self.actions = []
-        self.customContentView = nil
-        self.iconView = nil
+        self.init(
+            title: { "" },
+            message: message,
+            actions: [],
+            iconBuilder: nil,
+            customContentBuilder: nil
+        )
     }
     
+    /// Creates dialog content with just a message (closure-based).
+    ///
+    /// The title is empty by default.
+    /// - Parameter message: A closure that returns the dialog message.
+    public init(_ message: @escaping @Sendable () -> String) where Icon == EmptyView, CustomContent == EmptyView {
+        self.init(
+            title: { "" },
+            message: message,
+            actions: [],
+            iconBuilder: nil,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a message (plain value) and actions.
+    ///
+    /// The title is empty by default.
+    /// - Parameters:
+    ///   - message: The dialog message evaluated via @autoclosure.
+    ///   - actions: A builder that produces dialog actions.
     public init(_ message: @autoclosure @escaping @Sendable () -> String, @DialogActionsBuilder actions: () -> [any DialogAction]) where Icon == EmptyView, CustomContent == EmptyView {
-        self.title = { "" }
-        self.message = message
-        self.actions = actions()
-        self.customContentView = nil
-        self.iconView = nil
+        self.init(
+            title: { "" },
+            message: message,
+            actions: actions(),
+            iconBuilder: nil,
+            customContentBuilder: nil
+        )
     }
     
-    /// Creates dialog content with a title and a custom icon.
+    /// Creates dialog content with a message (closure-based) and actions.
+    ///
+    /// The title is empty by default.
+    /// - Parameters:
+    ///   - message: A closure that returns the dialog message.
+    ///   - actions: A builder that produces dialog actions.
+    public init(_ message: @escaping @Sendable () -> String, @DialogActionsBuilder actions: () -> [any DialogAction]) where Icon == EmptyView, CustomContent == EmptyView {
+        self.init(
+            title: { "" },
+            message: message,
+            actions: actions(),
+            iconBuilder: nil,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title (plain value) and a custom icon.
     ///
     /// - Parameters:
-    ///   - title: The title of the dialog.
-    ///   - icon: A custom icon to display with the dialog.
+    ///   - title: The dialog title evaluated via @autoclosure.
+    ///   - icon: A view builder that produces the icon view.
     public init(
         title: @autoclosure @escaping @Sendable () -> String,
         @ViewBuilder icon: @Sendable @escaping () -> Icon
     ) where CustomContent == EmptyView {
-        self.title = title
-        self.message = { nil }
-        self.actions = []
-        self.customContentView = nil
-        self.iconView = icon
+        self.init(
+            title: title,
+            message: { nil },
+            actions: [],
+            iconBuilder: icon,
+            customContentBuilder: nil
+        )
     }
     
-    /// Creates dialog content with a title, message and custom icon.
+    /// Creates dialog content with a title (closure-based) and a custom icon.
+    ///
+    /// - Parameters:
+    ///   - title: A closure that returns the dialog title.
+    ///   - icon: A view builder that produces the icon view.
+    public init(
+        title: @escaping @Sendable () -> String,
+        @ViewBuilder icon: @Sendable @escaping () -> Icon
+    ) where CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: { nil },
+            actions: [],
+            iconBuilder: icon,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title (plain value), message (plain value) and custom icon.
+    ///
+    /// - Parameters:
+    ///   - title: The dialog title evaluated via @autoclosure.
+    ///   - message: The optional dialog message evaluated via @autoclosure.
+    ///   - icon: A view builder that produces the icon view.
     public init(
         title: @autoclosure @escaping @Sendable () -> String,
         message: @autoclosure @escaping @Sendable () -> String?,
         @ViewBuilder icon: @Sendable @escaping () -> Icon
     ) where CustomContent == EmptyView {
-        self.title = title
-        self.message = message
-        self.actions = []
-        self.customContentView = nil
-        self.iconView = icon
+        self.init(
+            title: title,
+            message: message,
+            actions: [],
+            iconBuilder: icon,
+            customContentBuilder: nil
+        )
     }
     
-    /// Creates dialog content with a title and actions.
+    /// Creates dialog content with a title (closure-based), message (plain value) and custom icon.
     ///
     /// - Parameters:
-    ///   - title: The title of the dialog.
-    ///   - actions: A closure that builds the dialog actions using `DialogActionsBuilder`.
+    ///   - title: A closure that returns the dialog title.
+    ///   - message: The optional dialog message evaluated via @autoclosure.
+    ///   - icon: A view builder that produces the icon view.
+    public init(
+        title: @escaping @Sendable () -> String,
+        message: @autoclosure @escaping @Sendable () -> String?,
+        @ViewBuilder icon: @Sendable @escaping () -> Icon
+    ) where CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: message,
+            actions: [],
+            iconBuilder: icon,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title (plain value), message (closure-based) and custom icon.
+    ///
+    /// - Parameters:
+    ///   - title: The dialog title evaluated via @autoclosure.
+    ///   - message: A closure that returns the optional dialog message.
+    ///   - icon: A view builder that produces the icon view.
+    public init(
+        title: @autoclosure @escaping @Sendable () -> String,
+        message: @escaping @Sendable () -> String?,
+        @ViewBuilder icon: @Sendable @escaping () -> Icon
+    ) where CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: message,
+            actions: [],
+            iconBuilder: icon,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title and message (both closure-based) and a custom icon.
+    ///
+    /// - Parameters:
+    ///   - title: A closure that returns the dialog title.
+    ///   - message: A closure that returns the optional dialog message.
+    ///   - icon: A view builder that produces the icon view.
+    public init(
+        title: @escaping @Sendable () -> String,
+        message: @escaping @Sendable () -> String?,
+        @ViewBuilder icon: @Sendable @escaping () -> Icon
+    ) where CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: message,
+            actions: [],
+            iconBuilder: icon,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title (plain value) and actions.
+    ///
+    /// - Parameters:
+    ///   - title: The dialog title evaluated via @autoclosure.
+    ///   - actions: A builder that produces dialog actions.
     public init(
         title: @autoclosure @escaping @Sendable () -> String,
         @DialogActionsBuilder actions: () -> [any DialogAction]
     ) where Icon == EmptyView, CustomContent == EmptyView {
-        self.title = title
-        self.message = { nil }
-        self.actions = actions()
-        self.customContentView = nil
-        self.iconView = nil
+        self.init(
+            title: title,
+            message: { nil },
+            actions: actions(),
+            iconBuilder: nil,
+            customContentBuilder: nil
+        )
     }
     
-    /// Creates dialog content with a title, message, and actions.
+    /// Creates dialog content with a title (closure-based) and actions.
     ///
     /// - Parameters:
-    ///   - title: The title of the dialog.
-    ///   - message: An optional message for additional details.
-    ///   - actions: A closure that builds the dialog actions using `DialogActionsBuilder`.
+    ///   - title: A closure that returns the dialog title.
+    ///   - actions: A builder that produces dialog actions.
+    public init(
+        title: @escaping @Sendable () -> String,
+        @DialogActionsBuilder actions: () -> [any DialogAction]
+    ) where Icon == EmptyView, CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: { nil },
+            actions: actions(),
+            iconBuilder: nil,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title (plain value), message (plain value), and actions.
+    ///
+    /// - Parameters:
+    ///   - title: The dialog title evaluated via @autoclosure.
+    ///   - message: The optional dialog message evaluated via @autoclosure.
+    ///   - actions: A builder that produces dialog actions.
     public init(
         title: @autoclosure @escaping @Sendable () -> String,
         message: @autoclosure @escaping @Sendable () -> String?,
         @DialogActionsBuilder actions: () -> [any DialogAction]
     ) where Icon == EmptyView, CustomContent == EmptyView {
-        self.title = title
-        self.message = message
-        self.actions = actions()
-        self.customContentView = nil
-        self.iconView = nil
+        self.init(
+            title: title,
+            message: message,
+            actions: actions(),
+            iconBuilder: nil,
+            customContentBuilder: nil
+        )
     }
     
-    /// Creates dialog content with a title, custom icon, and actions.
+    /// Creates dialog content with a title (plain value), message (closure-based), and actions.
+    ///
+    /// - Parameters:
+    ///   - title: The dialog title evaluated via @autoclosure.
+    ///   - message: A closure that returns the optional dialog message.
+    ///   - actions: A builder that produces dialog actions.
+    public init(
+        title: @autoclosure @escaping @Sendable () -> String,
+        message: @escaping @Sendable () -> String?,
+        @DialogActionsBuilder actions: () -> [any DialogAction]
+    ) where Icon == EmptyView, CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: message,
+            actions: actions(),
+            iconBuilder: nil,
+            customContentBuilder: nil
+        )
+    }
+
+    /// Creates dialog content with a title and message (both closure-based), and actions.
+    ///
+    /// - Parameters:
+    ///   - title: A closure that returns the dialog title.
+    ///   - message: A closure that returns the optional dialog message.
+    ///   - actions: A builder that produces dialog actions.
+    public init(
+        title: @escaping @Sendable () -> String,
+        message: @escaping @Sendable () -> String?,
+        @DialogActionsBuilder actions: () -> [any DialogAction]
+    ) where Icon == EmptyView, CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: message,
+            actions: actions(),
+            iconBuilder: nil,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title (plain value), custom icon, and actions.
+    ///
+    /// - Parameters:
+    ///   - title: The dialog title evaluated via @autoclosure.
+    ///   - icon: A view builder that produces the icon view.
+    ///   - actions: A builder that produces dialog actions.
     public init(
         title: @autoclosure @escaping @Sendable () -> String,
         @ViewBuilder icon: @Sendable @escaping () -> Icon,
         @DialogActionsBuilder actions: () -> [any DialogAction]
     ) where CustomContent == EmptyView {
-        self.title = title
-        self.message = { nil }
-        self.actions = actions()
-        self.customContentView = nil
-        self.iconView = icon
+        self.init(
+            title: title,
+            message: { nil },
+            actions: actions(),
+            iconBuilder: icon,
+            customContentBuilder: nil
+        )
     }
     
-    /// Creates dialog content with a title, message, icon, and actions.
+    /// Creates dialog content with a title (closure-based), custom icon, and actions.
+    ///
+    /// - Parameters:
+    ///   - title: A closure that returns the dialog title.
+    ///   - icon: A view builder that produces the icon view.
+    ///   - actions: A builder that produces dialog actions.
+    public init(
+        title: @escaping @Sendable () -> String,
+        @ViewBuilder icon: @Sendable @escaping () -> Icon,
+        @DialogActionsBuilder actions: () -> [any DialogAction]
+    ) where CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: { nil },
+            actions: actions(),
+            iconBuilder: icon,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title (plain value), message (plain value), custom icon, and actions.
+    ///
+    /// - Parameters:
+    ///   - title: The dialog title evaluated via @autoclosure.
+    ///   - message: The optional dialog message evaluated via @autoclosure.
+    ///   - icon: A view builder that produces the icon view.
+    ///   - actions: A builder that produces dialog actions.
     public init(
         title: @autoclosure @escaping @Sendable () -> String,
         message: @autoclosure @escaping @Sendable () -> String?,
         @ViewBuilder icon: @Sendable @escaping () -> Icon,
         @DialogActionsBuilder actions: () -> [any DialogAction]
     ) where CustomContent == EmptyView {
-        self.title = title
-        self.message = message
-        self.actions = actions()
-        self.customContentView = nil
-        self.iconView = icon
+        self.init(
+            title: title,
+            message: message,
+            actions: actions(),
+            iconBuilder: icon,
+            customContentBuilder: nil
+        )
     }
     
+    /// Creates dialog content with a title (closure-based), message (plain value), custom icon, and actions.
+    ///
+    /// - Parameters:
+    ///   - title: A closure that returns the dialog title.
+    ///   - message: The optional dialog message evaluated via @autoclosure.
+    ///   - icon: A view builder that produces the icon view.
+    ///   - actions: A builder that produces dialog actions.
+    public init(
+        title: @escaping @Sendable () -> String,
+        message: @autoclosure @escaping @Sendable () -> String?,
+        @ViewBuilder icon: @Sendable @escaping () -> Icon,
+        @DialogActionsBuilder actions: () -> [any DialogAction]
+    ) where CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: message,
+            actions: actions(),
+            iconBuilder: icon,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title (plain value), message (closure-based), custom icon, and actions.
+    ///
+    /// - Parameters:
+    ///   - title: The dialog title evaluated via @autoclosure.
+    ///   - message: A closure that returns the optional dialog message.
+    ///   - icon: A view builder that produces the icon view.
+    ///   - actions: A builder that produces dialog actions.
+    public init(
+        title: @autoclosure @escaping @Sendable () -> String,
+        message: @escaping @Sendable () -> String?,
+        @ViewBuilder icon: @Sendable @escaping () -> Icon,
+        @DialogActionsBuilder actions: () -> [any DialogAction]
+    ) where CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: message,
+            actions: actions(),
+            iconBuilder: icon,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title and message (both closure-based), custom icon, and actions.
+    ///
+    /// - Parameters:
+    ///   - title: A closure that returns the dialog title.
+    ///   - message: A closure that returns the optional dialog message.
+    ///   - icon: A view builder that produces the icon view.
+    ///   - actions: A builder that produces dialog actions.
+    public init(
+        title: @escaping @Sendable () -> String,
+        message: @escaping @Sendable () -> String?,
+        @ViewBuilder icon: @Sendable @escaping () -> Icon,
+        @DialogActionsBuilder actions: () -> [any DialogAction]
+    ) where CustomContent == EmptyView {
+        self.init(
+            title: title,
+            message: message,
+            actions: actions(),
+            iconBuilder: icon,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title (plain value), message (plain value), image icon, and actions.
+    ///
+    /// - Parameters:
+    ///   - title: The dialog title evaluated via @autoclosure.
+    ///   - message: The optional dialog message evaluated via @autoclosure.
+    ///   - iconImage: An Image builder evaluated via @autoclosure.
+    ///   - actions: A builder that produces dialog actions.
     public init(
         title: @autoclosure @escaping @Sendable () -> String,
         message: @autoclosure @escaping @Sendable () -> String?,
         iconImage: @autoclosure @escaping @Sendable () -> Image,
         @DialogActionsBuilder actions: () -> [any DialogAction]
     ) where CustomContent == EmptyView, Icon == Image {
-        self.title = title
-        self.message = message
-        self.actions = actions()
-        self.customContentView = nil
-        self.iconView = iconImage
+        self.init(
+            title: title,
+            message: message,
+            actions: actions(),
+            iconBuilder: iconImage,
+            customContentBuilder: nil
+        )
     }
     
+    /// Creates dialog content with a title (closure-based), message (plain value), image icon, and actions.
+    ///
+    /// - Parameters:
+    ///   - title: A closure that returns the dialog title.
+    ///   - message: The optional dialog message evaluated via @autoclosure.
+    ///   - iconImage: An Image builder evaluated via @autoclosure.
+    ///   - actions: A builder that produces dialog actions.
+    public init(
+        title: @escaping @Sendable () -> String,
+        message: @autoclosure @escaping @Sendable () -> String?,
+        iconImage: @autoclosure @escaping @Sendable () -> Image,
+        @DialogActionsBuilder actions: () -> [any DialogAction]
+    ) where CustomContent == EmptyView, Icon == Image {
+        self.init(
+            title: title,
+            message: message,
+            actions: actions(),
+            iconBuilder: iconImage,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with a title (plain value), image icon, and actions.
+    ///
+    /// - Parameters:
+    ///   - title: The dialog title evaluated via @autoclosure.
+    ///   - iconImage: An Image builder evaluated via @autoclosure.
+    ///   - actions: A builder that produces dialog actions.
     public init(
         title: @autoclosure @escaping @Sendable () -> String,
         iconImage: @autoclosure @escaping @Sendable () -> Image,
         @DialogActionsBuilder actions: () -> [any DialogAction]
     ) where CustomContent == EmptyView, Icon == Image {
-        self.title = title
-        self.message = { nil }
-        self.actions = actions()
-        self.customContentView = nil
-        self.iconView = iconImage
+        self.init(
+            title: title,
+            message: { nil },
+            actions: actions(),
+            iconBuilder: iconImage,
+            customContentBuilder: nil
+        )
     }
     
-    /// Creates dialog content with custom view using generic type.
+    /// Creates dialog content with a title (closure-based), image icon, and actions.
     ///
     /// - Parameters:
-    ///   - title: Optional title for accessibility
-    ///   - customContent: A view builder that creates the custom content
-    /// - Returns: DialogContent with generic custom view type
+    ///   - title: A closure that returns the dialog title.
+    ///   - iconImage: An Image builder evaluated via @autoclosure.
+    ///   - actions: A builder that produces dialog actions.
+    public init(
+        title: @escaping @Sendable () -> String,
+        iconImage: @autoclosure @escaping @Sendable () -> Image,
+        @DialogActionsBuilder actions: () -> [any DialogAction]
+    ) where CustomContent == EmptyView, Icon == Image {
+        self.init(
+            title: title,
+            message: { nil },
+            actions: actions(),
+            iconBuilder: iconImage,
+            customContentBuilder: nil
+        )
+    }
+    
+    /// Creates dialog content with custom SwiftUI content.
+    ///
+    /// When provided, the custom content replaces the standard title/message layout.
+    /// The title is used primarily for accessibility.
+    /// - Parameters:
+    ///   - title: The dialog title evaluated via @autoclosure. Defaults to an empty string.
+    ///   - customContent: A view builder that produces the custom content.
     public init(
         title: @autoclosure @escaping @Sendable () -> String = "",
         @ViewBuilder customContent: @Sendable @escaping () -> CustomContent
     ) where Icon == EmptyView {
-        self.title = title
-        self.message = { nil }
-        self.actions = []
-        self.customContentView = customContent
-        self.iconView = nil
+        self.init(
+            title: title,
+            message: { nil },
+            actions: [],
+            iconBuilder: nil,
+            customContentBuilder: customContent
+        )
+    }
+    
+    /// Creates dialog content with custom SwiftUI content (closure-based title).
+    ///
+    /// When provided, the custom content replaces the standard title/message layout.
+    /// The title is used primarily for accessibility.
+    /// - Parameters:
+    ///   - title: A closure that returns the dialog title.
+    ///   - customContent: A view builder that produces the custom content.
+    public init(
+        title: @escaping @Sendable () -> String,
+        @ViewBuilder customContent: @Sendable @escaping () -> CustomContent
+    ) where Icon == EmptyView {
+        self.init(
+            title: title,
+            message: { nil },
+            actions: [],
+            iconBuilder: nil,
+            customContentBuilder: customContent
+        )
     }
     
     // MARK: - Internal Initializers for Type Erasure
@@ -350,3 +775,4 @@ extension DialogContent {
         return AnyView(iconView())
     }
 }
+

--- a/UDF/View/Dialog/Content/DialogContent.swift
+++ b/UDF/View/Dialog/Content/DialogContent.swift
@@ -18,20 +18,21 @@ import SwiftUI
 /// more than a simple message string. It supports titles, optional messages, interactive
 /// actions, and completely custom SwiftUI views for maximum flexibility.
 ///
-/// This replaces the need for complex configurations and provides a unified content
-/// model that works across all dialog styles while supporting the rich custom
-/// content capabilities previously available in toast-specific implementations.
+/// The `title` and `message` are modeled as closures to allow dynamic resolution
+/// at presentation time (for example, for localization or state-dependent content).
+/// Convenience initializers using `@autoclosure` are provided so you can still
+/// pass plain strings ergonomically.
 ///
 /// ## Usage:
 /// ```swift
 /// // Simple content with just a title
-/// let content = DialogContent("Delete Item")
+/// let content = DialogContent(title: "Delete Item")
 ///
 /// // Content with title and message
-/// let content = DialogContent("Delete Item", message: "This cannot be undone")
+/// let content = DialogContent(title: "Delete Item", message: "This cannot be undone")
 ///
 /// // Content with title, message, and actions
-/// let content = DialogContent("Delete Item", message: "This cannot be undone") {
+/// let content = DialogContent(title: "Delete Item", message: "This cannot be undone") {
 ///     DialogButton.destructive("Delete") {
 ///         performDelete()
 ///     }
@@ -39,19 +40,19 @@ import SwiftUI
 /// }
 ///
 /// // Custom view content for rich toast dialogs
-/// let content = DialogContent(customView: AnyView(
+/// let content = DialogContent(customContent: {
 ///     VStack {
 ///         ProgressView()
 ///         Text("Uploading...")
 ///     }
-/// ))
+/// })
 /// ```
 public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendable {
-    /// The title of the dialog content.
-    public let title: String
+    /// The title provider of the dialog content.
+    public let title: @Sendable () -> String
     
-    /// An optional message providing additional details.
-    public let message: String?
+    /// An optional message provider providing additional details.
+    public let message: @Sendable () -> String?
     
     /// The interactive actions available for this content.
     public let actions: [any DialogAction]
@@ -68,21 +69,6 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
     /// Supports various icon types including SF Symbols, custom images, and
     /// arbitrary SwiftUI views. When nil, the dialog system will use
     /// semantic defaults based on the dialog category.
-    ///
-    /// ## Examples:
-    /// ```swift
-    /// // Custom SF Symbol
-    /// DialogContent("Success", icon: .systemImage("party.popper.fill"))
-    ///
-    /// // Custom image
-    /// DialogContent("Welcome", icon: .image("company-logo"))
-    ///
-    /// // Custom view
-    /// DialogContent("Loading", icon: .view(AnyView(ProgressView())))
-    ///
-    /// // No icon (override semantic default)
-    /// DialogContent("Clean message", icon: .none)
-    /// ```
     public let iconView: (@Sendable () -> Icon)?
     
     // MARK: - Computed Properties
@@ -98,7 +84,10 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
     
     /// Whether this content has a message.
     public var hasMessage: Bool {
-        message != nil && !message!.isEmpty
+        if let msg = message() {
+            return !msg.isEmpty
+        }
+        return false
     }
     
     /// Whether this content uses a custom view instead of standard layout.
@@ -115,9 +104,9 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
     /// Creates dialog content with a title only.
     ///
     /// - Parameter title: The title of the dialog.
-    public init(title: String) where Icon == EmptyView, CustomContent == EmptyView {
+    public init(title: @autoclosure @escaping @Sendable () -> String) where Icon == EmptyView, CustomContent == EmptyView {
         self.title = title
-        self.message = nil
+        self.message = { nil }
         self.actions = []
         self.customContentView = nil
         self.iconView = nil
@@ -128,7 +117,7 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
     /// - Parameters:
     ///   - title: The title of the dialog.
     ///   - message: An optional message for additional details.
-    public init(title: String, message: String?) where Icon == EmptyView, CustomContent == EmptyView {
+    public init(title: @autoclosure @escaping @Sendable () -> String, message: @autoclosure @escaping @Sendable () -> String?) where Icon == EmptyView, CustomContent == EmptyView {
         self.title = title
         self.message = message
         self.actions = []
@@ -141,32 +130,43 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
     /// This is a convenience initializer for simple dialogs that only need
     /// to display a message without additional content or actions.
     ///
-    /// - Parameter message: The message to display (becomes the title).
-    public init(_ message: String) where Icon == EmptyView, CustomContent == EmptyView {
-        self.title = ""
+    /// - Parameter message: The message to display.
+    public init(_ message: @autoclosure @escaping @Sendable () -> String) where Icon == EmptyView, CustomContent == EmptyView {
+        self.title = { "" }
         self.message = message
         self.actions = []
         self.customContentView = nil
         self.iconView = nil
     }
     
-    public init(_ message: String, @DialogActionsBuilder actions: () -> [any DialogAction]) where Icon == EmptyView, CustomContent == EmptyView {
-        self.title = ""
+    public init(_ message: @autoclosure @escaping @Sendable () -> String, @DialogActionsBuilder actions: () -> [any DialogAction]) where Icon == EmptyView, CustomContent == EmptyView {
+        self.title = { "" }
         self.message = message
         self.actions = actions()
         self.customContentView = nil
         self.iconView = nil
     }
     
-    /// Creates dialog content with a title, message, and custom icon.
+    /// Creates dialog content with a title and a custom icon.
     ///
     /// - Parameters:
     ///   - title: The title of the dialog.
-    ///   - message: An optional message for additional details.
     ///   - icon: A custom icon to display with the dialog.
     public init(
-        title: String,
-        message: String? = nil,
+        title: @autoclosure @escaping @Sendable () -> String,
+        @ViewBuilder icon: @Sendable @escaping () -> Icon
+    ) where CustomContent == EmptyView {
+        self.title = title
+        self.message = { nil }
+        self.actions = []
+        self.customContentView = nil
+        self.iconView = icon
+    }
+    
+    /// Creates dialog content with a title, message and custom icon.
+    public init(
+        title: @autoclosure @escaping @Sendable () -> String,
+        message: @autoclosure @escaping @Sendable () -> String?,
         @ViewBuilder icon: @Sendable @escaping () -> Icon
     ) where CustomContent == EmptyView {
         self.title = title
@@ -182,11 +182,11 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
     ///   - title: The title of the dialog.
     ///   - actions: A closure that builds the dialog actions using `DialogActionsBuilder`.
     public init(
-        title: String,
+        title: @autoclosure @escaping @Sendable () -> String,
         @DialogActionsBuilder actions: () -> [any DialogAction]
     ) where Icon == EmptyView, CustomContent == EmptyView {
         self.title = title
-        self.message = nil
+        self.message = { nil }
         self.actions = actions()
         self.customContentView = nil
         self.iconView = nil
@@ -199,8 +199,8 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
     ///   - message: An optional message for additional details.
     ///   - actions: A closure that builds the dialog actions using `DialogActionsBuilder`.
     public init(
-        title: String,
-        message: String?,
+        title: @autoclosure @escaping @Sendable () -> String,
+        message: @autoclosure @escaping @Sendable () -> String?,
         @DialogActionsBuilder actions: () -> [any DialogAction]
     ) where Icon == EmptyView, CustomContent == EmptyView {
         self.title = title
@@ -210,16 +210,23 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
         self.iconView = nil
     }
     
-    /// Creates dialog content with a title, message, icon, and actions.
-    ///
-    /// - Parameters:
-    ///   - title: The title of the dialog.
-    ///   - message: An optional message for additional details.
-    ///   - icon: A custom icon to display with the dialog.
-    ///   - actions: A closure that builds the dialog actions using `DialogActionsBuilder`.
+    /// Creates dialog content with a title, custom icon, and actions.
     public init(
-        title: String,
-        message: String? = nil,
+        title: @autoclosure @escaping @Sendable () -> String,
+        @ViewBuilder icon: @Sendable @escaping () -> Icon,
+        @DialogActionsBuilder actions: () -> [any DialogAction]
+    ) where CustomContent == EmptyView {
+        self.title = title
+        self.message = { nil }
+        self.actions = actions()
+        self.customContentView = nil
+        self.iconView = icon
+    }
+    
+    /// Creates dialog content with a title, message, icon, and actions.
+    public init(
+        title: @autoclosure @escaping @Sendable () -> String,
+        message: @autoclosure @escaping @Sendable () -> String?,
         @ViewBuilder icon: @Sendable @escaping () -> Icon,
         @DialogActionsBuilder actions: () -> [any DialogAction]
     ) where CustomContent == EmptyView {
@@ -231,13 +238,25 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
     }
     
     public init(
-        title: String,
-        message: String? = nil,
+        title: @autoclosure @escaping @Sendable () -> String,
+        message: @autoclosure @escaping @Sendable () -> String?,
         iconImage: @autoclosure @escaping @Sendable () -> Image,
         @DialogActionsBuilder actions: () -> [any DialogAction]
     ) where CustomContent == EmptyView, Icon == Image {
         self.title = title
         self.message = message
+        self.actions = actions()
+        self.customContentView = nil
+        self.iconView = iconImage
+    }
+    
+    public init(
+        title: @autoclosure @escaping @Sendable () -> String,
+        iconImage: @autoclosure @escaping @Sendable () -> Image,
+        @DialogActionsBuilder actions: () -> [any DialogAction]
+    ) where CustomContent == EmptyView, Icon == Image {
+        self.title = title
+        self.message = { nil }
         self.actions = actions()
         self.customContentView = nil
         self.iconView = iconImage
@@ -250,11 +269,11 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
     ///   - customContent: A view builder that creates the custom content
     /// - Returns: DialogContent with generic custom view type
     public init(
-        title: String = "",
+        title: @autoclosure @escaping @Sendable () -> String = "",
         @ViewBuilder customContent: @Sendable @escaping () -> CustomContent
     ) where Icon == EmptyView {
         self.title = title
-        self.message = nil
+        self.message = { nil }
         self.actions = []
         self.customContentView = customContent
         self.iconView = nil
@@ -267,11 +286,11 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
     /// This initializer is designed specifically for the `eraseToAnyDialogContent()` method
     /// and handles all possible combinations of icon and custom content.
     internal init(
-        title: String,
-        message: String? = nil,
+        title: @Sendable @escaping () -> String,
+        message: @Sendable @escaping () -> String? = { nil },
         actions: [any DialogAction] = [],
         iconBuilder: (@Sendable () -> Icon)? = nil,
-        customContentBuilder: (@Sendable () -> CustomContent)? = nil,
+        customContentBuilder: (@Sendable () -> CustomContent)? = nil
     ) {
         self.title = title
         self.message = message
@@ -286,8 +305,8 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
     /// Note: Actions are compared by their hash values since they may contain closures
     /// that cannot be directly compared.
     public static func == (lhs: DialogContent, rhs: DialogContent) -> Bool {
-        lhs.title == rhs.title &&
-        lhs.message == rhs.message &&
+        lhs.title() == rhs.title() &&
+        lhs.message() == rhs.message() &&
         lhs.actions.count == rhs.actions.count &&
         zip(lhs.actions, rhs.actions).allSatisfy { lhsAction, rhsAction in
             // Compare actions by their hash values
@@ -299,8 +318,8 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
 // MARK: - Hashable Support
 extension DialogContent: Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(title)
-        hasher.combine(message)
+        hasher.combine(title())
+        hasher.combine(message())
         hasher.combine(actions.count)
         hasher.combine(hasCustomView)
         hasher.combine(hasIcon)

--- a/UDF/View/Dialog/Content/DialogContent.swift
+++ b/UDF/View/Dialog/Content/DialogContent.swift
@@ -706,11 +706,20 @@ public struct DialogContent<Icon: View, CustomContent: View>: Equatable, Sendabl
     
     // MARK: - Internal Initializers for Type Erasure
     
-    /// Internal initializer for type erasure - handles all combinations with optional builders.
+    /// Designated initializer used by all public overloads.
     ///
-    /// This initializer is designed specifically for the `eraseToAnyDialogContent()` method
-    /// and handles all possible combinations of icon and custom content.
-    internal init(
+    /// This initializer centralizes the setup of `DialogContent` to avoid duplication across
+    /// multiple convenience initializers. It accepts lazy providers for title and message,
+    /// an explicit array of actions, and optional builders for icon and custom content.
+    /// All values are stored as closures to support deferred evaluation at presentation time.
+    ///
+    /// - Parameters:
+    ///   - title: A closure that returns the dialog title. Evaluated lazily.
+    ///   - message: A closure that returns an optional message. Defaults to a provider returning `nil`.
+    ///   - actions: The actions to associate with this content. Defaults to an empty array.
+    ///   - iconBuilder: An optional view builder that produces the icon view. Defaults to `nil`.
+    ///   - customContentBuilder: An optional view builder that produces the custom content. Defaults to `nil`.
+    private init(
         title: @Sendable @escaping () -> String,
         message: @Sendable @escaping () -> String? = { nil },
         actions: [any DialogAction] = [],

--- a/UDF/View/Dialog/Core/DialogType.swift
+++ b/UDF/View/Dialog/Core/DialogType.swift
@@ -52,14 +52,14 @@ public enum DialogCustomType<Icon: View, Content: View>: DialogTypeProtocol {
     public var title: String {
         switch self {
         case let .custom(content, _):
-            return content.title
+            return content.title()
         }
     }
 
     public var message: String? {
         switch self {
         case let .custom(content, _):
-            return content.message
+            return content.message()
         }
     }
 


### PR DESCRIPTION
### Description
This merge request makes dialog/alert text generation safe for Swift Concurrency and enables *lazy* resolution of titles/messages at presentation time (useful for localization, state-dependent strings, and avoiding capturing non-sendable state). To keep call sites ergonomic, many APIs now accept plain strings via `@autoclosure` while internally storing `title`/`message` as `@Sendable` closures.

### Changes Made
- **AlertBuilder: enforce concurrency-safe text providers**
  - Updated `AlertType` payloads and public initializers to require `@Sendable` text closures (`validationError`, `success`, `failure`, `message`, and `customActions`).
  - Adjusted the title/message variant to use `@autoclosure @Sendable` for the title and to evaluate/store the title closure appropriately.

- **DialogContent: switch from stored Strings to lazy providers**
  - Replaced:
    - `public let title: String` → `public let title: @Sendable () -> String`
    - `public let message: String?` → `public let message: @Sendable () -> String?`
  - Updated logic that depends on message presence (`hasMessage`) to call `message()` rather than reading a stored optional.
  - Added/expanded a large set of **convenience initializers** to support combinations of:
    - plain values (`@autoclosure`) vs closure-based inputs,
    - optional message,
    - actions builder,
    - custom icon builders / image icons,
    - custom SwiftUI content.
  - Centralized construction through a **single private designated initializer** that stores everything as closures and accepts optional icon/custom-content builders.

- **Equality/Hashing updated for closure-backed fields**
  - `Equatable` and `Hashable` now compare/hash evaluated values (`title()` / `message()`) instead of comparing closure references.

- **DialogType integration**
  - `DialogCustomType` now reads dialog text by evaluating providers (`content.title()` / `content.message()`) instead of accessing stored strings.