### PR TITLE
Fix EXC_BAD_ACCESS in IsolatedState by implementing cancellable subscription

### DIFF
--- a/UDF/Common/Extensions/Publishers+AsyncState.swift
+++ b/UDF/Common/Extensions/Publishers+AsyncState.swift
@@ -9,8 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@preconcurrency import Combine
+import Combine
 import Foundation
+import os
 
 public extension Publishers {
     /// Returns an `AnyPublisher` that publishes an isolated, immutable state from the given store.
@@ -22,16 +23,73 @@ public extension Publishers {
     /// - Parameter store: An instance conforming to `Store<State>` from which the state is retrieved.
     /// - Returns: An `AnyPublisher` that emits the isolated state of the store once.
     static func IsolatedState<State: AppReducer>(from store: any Store<State>) -> AnyPublisher<State, Never> {
-        Deferred {
-            Future<State, Never> { promise in
-                nonisolated(unsafe) let promise = promise
+        AsyncStatePublisher(store: store)
+            .eraseToAnyPublisher()
+    }
+}
 
-                Task(priority: .high) { @Sendable in
-                    let immutableState = await store.state
-                    promise(.success(immutableState))
-                }
+/// A custom publisher that fetches state asynchronously and supports cancellation.
+private struct AsyncStatePublisher<State: AppReducer>: Publisher {
+    typealias Output = State
+    typealias Failure = Never
+    
+    let store: any Store<State>
+    
+    func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
+        subscriber.receive(
+            subscription: AsyncStateSubscription(
+                subscriber: AnySubscriber(subscriber),
+                store: store
+            )
+        )
+    }
+}
+
+/// A subscription that manages the concurrent task for fetching state.
+private final class AsyncStateSubscription<State: AppReducer>: Subscription, @unchecked Sendable {
+    private struct MutableState: @unchecked Sendable {
+        var subscriber: AnySubscriber<State, Never>?
+        var task: Task<Void, Never>?
+    }
+    
+    private let state: OSAllocatedUnfairLock<MutableState>
+    private let store: any Store<State>
+    
+    init(subscriber: AnySubscriber<State, Never>?, store: any Store<State>) {
+        self.state = OSAllocatedUnfairLock(initialState: MutableState(subscriber: subscriber, task: nil))
+        self.store = store
+    }
+    
+    func request(_ demand: Subscribers.Demand) {
+        state.withLock { mutableState in
+            guard mutableState.task == nil, mutableState.subscriber != nil else {
+                return
+            }
+            
+            mutableState.task = Task.detached(priority: .userInitiated) { [weak self] in
+                guard let fetchedState = await self?.store.state else { return }
+                self?.deliver(fetchedState)
             }
         }
-        .eraseToAnyPublisher()
+    }
+    
+    private func deliver(_ fetchedState: State) {
+        state.withLock { mutableState in
+            guard let sub = mutableState.subscriber else { return }
+            
+            _ = sub.receive(fetchedState)
+            sub.receive(completion: .finished)
+            
+            mutableState.subscriber = nil
+            mutableState.task = nil
+        }
+    }
+    
+    func cancel() {
+        state.withLock { mutableState in
+            mutableState.task?.cancel()
+            mutableState.task = nil
+            mutableState.subscriber = nil
+        }
     }
 }


### PR DESCRIPTION
### Description
This merge request replaces the previous `Deferred + Future + Task` implementation used to publish a one-shot “isolated state” from a `Store` with a dedicated custom Combine publisher/subscription pair. The change addresses two main issues with the earlier approach: lack of proper cancellation handling and weaker control over concurrency/thread-safety around the subscriber lifecycle. By owning the subscription, the publisher can start the async fetch only when demand is requested, safely deliver exactly once, and reliably cancel the in-flight task if the downstream cancels.

An alternative (the previous `Future`-based approach) was effectively fire-and-forget once the `Task` started and didn’t model Combine cancellation semantics cleanly; the new implementation aligns better with Combine’s subscription contract.

### Changes Made
- Removed `@preconcurrency import Combine` and switched to `import Combine`, adding `import os` to support locking.
- Reimplemented `Publishers.IsolatedState(from:)` to use a new custom publisher:
  - Introduced `AsyncStatePublisher` (`Publisher`) and `AsyncStateSubscription` (`Subscription`) to manage the async state fetch.
- Added cancellation and lifecycle control:
  - Starts a detached task only upon `request(_:)` and prevents multiple tasks from being created.
  - Implements `cancel()` to cancel the task and release the subscriber.
- Added thread-safe mutable subscription state using `OSAllocatedUnfairLock`:
  - Stores and protects access to the downstream subscriber and the running task.
  - Ensures single delivery (`receive` + `.finished`) and then clears references to avoid repeated sends/leaks.