### PR TITLE
Update CI workflow to use macOS 26 and Xcode 26.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ concurrency:
 jobs:
   testing:
     name: Run all tests
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       UNDER_TEST: "1"
     
     strategy:
       fail-fast: false
       matrix:
-        xcode: ['16.4']
+        xcode: ['26.3']
         
     steps:
     - name: Checkout


### PR DESCRIPTION
### Description
This merge request updates the CI environment to use a newer macOS runner and Xcode toolchain, aligning automated test runs with the intended/current Apple development stack. This is necessary to ensure tests compile and execute under the same SDK/compiler versions developers target, and to avoid incompatibilities that can arise when CI lags behind the required Xcode/macOS versions.

### Changes Made
- Updated GitHub Actions runner image:
  - `runs-on: macos-15` → `runs-on: macos-26`
- Updated the Xcode version used in the CI matrix:
  - `xcode: ['16.4']` → `xcode: ['26.3']`
- Minor formatting fix: ensured the workflow file ends with a newline (no functional impact).