### PR TITLE
Feature/make dialogregistry internal and expose its api via dialog guid 869cdbv18

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/Dialog/DialogDSLTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/DialogDSLTests.swift
@@ -161,14 +161,14 @@ struct DialogDSLTests {
     func dynamicDialogRegistrationUsesDSL() {
         let id = 123
         
-        DialogRegistry.register(id: id) {
+        Dialog.register(id: id) {
             AlertDialog {
                 DialogTitle("Dynamic Registry AlertDialog")
                 DialogButton(title: "Dismiss", action: {})
             }
         }
         
-        let retrieved = DialogRegistry.get(id: id)
+        let retrieved = _DialogRegistry.get(id: id)
         #expect(retrieved != nil)
         #expect(retrieved?.title == "Dynamic Registry AlertDialog")
         #expect(retrieved?.actions.count == 1)
@@ -413,20 +413,20 @@ struct DialogDSLTests {
     func registryOverwritesBehavior() {
         let id = 777
         
-        DialogRegistry.register(id: id) {
+        Dialog.register(id: id) {
             AlertDialog {
                 DialogTitle("First")
             }
         }
         
-        #expect(DialogRegistry.get(id: id)?.title == "First")
+        #expect(_DialogRegistry.get(id: id)?.title == "First")
         
-        DialogRegistry.register(id: id) {
+        Dialog.register(id: id) {
             AlertDialog {
                 DialogTitle("Second")
             }
         }
         
-        #expect(DialogRegistry.get(id: id)?.title == "Second")
+        #expect(_DialogRegistry.get(id: id)?.title == "Second")
     }
 }

--- a/Tests/SwiftUI-UDF-Tests/Dialog/DialogDSLTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/DialogDSLTests.swift
@@ -13,12 +13,9 @@ import SwiftUI
 @testable import UDF
 import Testing
 
+// MARK: - DSL Tests
 @MainActor
-struct DialogDSLTests {
-    
-    init() {
-        DialogRegistry.clearAll()
-    }
+extension DialogTests {
 
     @Test("AlertDialog builder creates correct payload and applies properties")
     func alertBuilderAppliesPropertiesCorrectly() {

--- a/Tests/SwiftUI-UDF-Tests/Dialog/DialogQueueTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/DialogQueueTests.swift
@@ -497,7 +497,7 @@ import UDFSwiftTesting
         #expect(queueManager.queuedToasts.count == 1)
 
         // Wait for both toasts to auto-dismiss
-        await sleep(for: 0.5)
+        await sleep(for: 1.0)
 
         #expect(callback1Executed, "First toast callback should execute")
         #expect(callback2Executed, "Second toast callback should execute after first is dismissed")

--- a/Tests/SwiftUI-UDF-Tests/Dialog/DialogTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/DialogTests.swift
@@ -43,16 +43,14 @@ extension DialogType {
     static func customViewToast() -> Toast {
         Toast(config: .init(position: .center)) {
             DialogView {
-                AnyView(
-                    VStack {
-                        Image(systemName: "checkmark.circle.fill")
-                            .font(.largeTitle)
-                            .foregroundColor(.green)
-                        Text("Custom View Toast")
-                            .font(.headline)
-                    }
-                    .padding()
-                )
+                VStack {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.largeTitle)
+                        .foregroundColor(.green)
+                    Text("Custom View Toast")
+                        .font(.headline)
+                }
+                .padding()
             }
         }
     }

--- a/Tests/SwiftUI-UDF-Tests/Dialog/DialogTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/DialogTests.swift
@@ -106,6 +106,7 @@ extension DialogType {
                 print("Custom dialog action")
             }
         }
+        await waitForCondition { Dialog.isRegistered(id: FormWithDialog.DialogId.dialogWithAction) }
 
         await store.dispatch(Actions.PresentDialogWithAction())
         let success = await waitForCondition { await store.state.form.dialog.status != .dismissed }
@@ -179,6 +180,7 @@ extension DialogType {
                 print("Toast action executed")
             }
         }
+        await waitForCondition { Dialog.isRegistered(id: FormWithDialog.DialogId.toastDialog) }
 
         await store.dispatch(Actions.PresentToastDialog())
         let success = await waitForCondition { await store.state.form.dialog.status != .dismissed }
@@ -202,6 +204,7 @@ extension DialogType {
         await Dialog.register(id: FormWithDialog.DialogId.customToastWithIcon) {
             DialogType.customToastWithIcon()
         }
+        await waitForCondition { Dialog.isRegistered(id: FormWithDialog.DialogId.customToastWithIcon) }
 
         await store.dispatch(Actions.PresentCustomToastWithIcon())
         let success = await waitForCondition { await store.state.form.dialog.status != .dismissed }
@@ -231,6 +234,7 @@ extension DialogType {
         await Dialog.register(id: FormWithDialog.DialogId.customViewToast) {
             DialogType.customViewToast()
         }
+        await waitForCondition { Dialog.isRegistered(id: FormWithDialog.DialogId.customViewToast) }
 
         await store.dispatch(Actions.PresentCustomViewToast())
         let success = await waitForCondition { await store.state.form.dialog.status != .dismissed }
@@ -351,6 +355,7 @@ extension DialogType {
                 DialogMessage("This toast should be manually dismissed")
             }
         }
+        await waitForCondition { Dialog.isRegistered(id: FormWithDialog.DialogId.toastDialog) }
         
         // Present the toast
         await store.dispatch(Actions.PresentToastDialog())
@@ -375,6 +380,7 @@ extension DialogType {
                 DialogMessage("This toast should not auto-dismiss")
             }
         }
+        await waitForCondition { Dialog.isRegistered(id: FormWithDialog.DialogId.toastDialog) }
         
         // Present the toast
         await store.dispatch(Actions.PresentToastDialog())

--- a/Tests/SwiftUI-UDF-Tests/Dialog/DialogTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/DialogTests.swift
@@ -12,60 +12,49 @@ private extension Actions {
 
 extension DialogType {
     @MainActor
-    static func dialogWithAction(_ action: @Sendable @escaping () -> Void) -> DialogCustomType<EmptyView, EmptyView> {
-        DialogCustomType.custom(
-            content: DialogContent(
-                title: "Custom dialog title with action",
-                message: "Custom dialog text with action", actions: {
-                    DialogButton(title: "Action button", action: action)
-                    DialogButton(title: "Cancel")
-                        .role(.cancel)
-                }
-            ),
-            style: .alert
-        )
+    static func dialogWithAction(_ action: @Sendable @escaping () -> Void) -> AlertDialog {
+        AlertDialog {
+            DialogTitle("Custom dialog title with action")
+            DialogMessage("Custom dialog text with action")
+            DialogButton(title: "Action button", action: action)
+            DialogButton(title: "Cancel").role(.cancel)
+        }
     }
 
     @MainActor
-    static func toastWithAction(_ action: @Sendable @escaping () -> Void) -> DialogCustomType<EmptyView, EmptyView> {
-        DialogCustomType.custom(
-            content: DialogContent(
-                title: "Toast dialog",
-                message: "Toast with action button",
-                actions: {
-                    DialogButton(title: "Action", action: action)
-                }
-            ),
-            style: .toast()
-        )
+    static func toastWithAction(_ action: @Sendable @escaping () -> Void) -> Toast {
+        Toast {
+            DialogMessage("Toast with action button")
+            DialogButton(title: "Action", action: action)
+        }
     }
 
-    static func customToastWithIcon() -> DialogCustomType<Image, EmptyView> {
-        DialogCustomType.custom(
-            content: DialogContent(
-                title: "Custom Toast",
-                message: "Toast with custom icon",
-                iconImage: Image(systemName: "party.popper.fill"),
-                actions: {}
-            ),
-            style: .toast(.vibrant)
-        )
+    @MainActor
+    static func customToastWithIcon() -> Toast {
+        Toast(config: .init(theme: .vibrant)) {
+            DialogMessage("Toast with custom icon")
+            DialogIcon {
+                Image(systemName: "party.popper.fill")
+            }
+        }
     }
 
-    static func customViewToast() -> any DialogTypeProtocol {
-        DialogCustomType.custom(
-            content: DialogContent {
-                VStack {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.largeTitle)
-                        .foregroundColor(.green)
-                    Text("Custom View Toast")
-                        .font(.headline)
-                }
-                .padding()
-            },
-            style: .toast(.center)
-        )
+    @MainActor
+    static func customViewToast() -> Toast {
+        Toast(config: .init(position: .center)) {
+            DialogView {
+                AnyView(
+                    VStack {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.largeTitle)
+                            .foregroundColor(.green)
+                        Text("Custom View Toast")
+                            .font(.headline)
+                    }
+                    .padding()
+                )
+            }
+        }
     }
 }
 
@@ -105,21 +94,17 @@ extension DialogType {
     }
 
     init() {
-        DialogRegistry.clearAll()
+        Dialog.clearAll()
     }
 
     @Test func whendialogRegistered_dialogCanBePresentedById() async {
         let store = await TestStore(initial: AppState())
         #expect(await store.state.form.dialog.status == .dismissed)
 
-        let dialogWithAction = await MainActor.run {
+        await Dialog.register(id: FormWithDialog.DialogId.dialogWithAction) {
             DialogType.dialogWithAction {
                 print("Custom dialog action")
             }
-        }
-        
-        DialogRegistry.register(id: FormWithDialog.DialogId.dialogWithAction) {
-            dialogWithAction
         }
 
         await store.dispatch(Actions.PresentDialogWithAction())
@@ -189,14 +174,10 @@ extension DialogType {
         let store = await TestStore(initial: AppState())
         #expect(await store.state.form.dialog.status == .dismissed)
 
-        let toastWithAction = await MainActor.run {
+        await Dialog.register(id: FormWithDialog.DialogId.toastDialog) {
             DialogType.toastWithAction {
                 print("Toast action executed")
             }
-        }
-        
-        DialogRegistry.register(id: FormWithDialog.DialogId.toastDialog) {
-            toastWithAction
         }
 
         await store.dispatch(Actions.PresentToastDialog())
@@ -218,7 +199,7 @@ extension DialogType {
     @Test func customToastWithIcon() async {
         let store = await TestStore(initial: AppState())
 
-        DialogRegistry.register(id: FormWithDialog.DialogId.customToastWithIcon) {
+        await Dialog.register(id: FormWithDialog.DialogId.customToastWithIcon) {
             DialogType.customToastWithIcon()
         }
 
@@ -227,18 +208,18 @@ extension DialogType {
         #expect(success)
 
         // Verify it's a toast with custom icon
-        if case .presented(let dialogType) = await store.state.form.dialog.status,
-           case DialogCustomType<Image, EmptyView>.custom(let content, let style) = dialogType {
+        if case .presented(let dialogProtocol) = await store.state.form.dialog.status,
+           let toast = dialogProtocol as? Toast {
 
             // Check style is toast
-            if case .toast(let config) = style {
+            if case .toast(let config) = toast.style {
                 #expect(config.theme == .vibrant)
             } else {
                 Issue.record("Expected toast style")
             }
 
             // Check custom icon
-            #expect(content.hasIcon)
+            #expect(toast.payload.icon != nil)
         } else {
             Issue.record("Expected custom dialog with content")
         }
@@ -247,7 +228,7 @@ extension DialogType {
     @Test func customViewToast() async {
         let store = await TestStore(initial: AppState())
 
-        DialogRegistry.register(id: FormWithDialog.DialogId.customViewToast) {
+        await Dialog.register(id: FormWithDialog.DialogId.customViewToast) {
             DialogType.customViewToast()
         }
 
@@ -256,18 +237,18 @@ extension DialogType {
         #expect(success)
 
         // Verify it's a toast with custom view
-        if case .presented(let dialogType) = await store.state.form.dialog.status {
+        if case .presented(let dialogProtocol) = await store.state.form.dialog.status {
             // Check style is toast
-            if case .toast(let config) = dialogType.style {
+            if case .toast(let config) = dialogProtocol.style {
                 #expect(config.position == .center)
             } else {
                 Issue.record("Expected toast style")
             }
 
             // Check custom view
-            #expect(!(dialogType is DialogType))
+            #expect(!(dialogProtocol is DialogType))
             await MainActor.run {
-                #expect(dialogType.getCustomContentView() != nil)
+                #expect(dialogProtocol.getCustomContentView() != nil)
             }
         } else {
             Issue.record("Expected custom dialog with custom view")
@@ -299,14 +280,14 @@ extension DialogType {
     // MARK: - Complex Content Tests
     @MainActor
     @Test func customDialogWithContent() {
-        let dialog = DialogStatus(style: .alert) {
-            DialogContent(title: "Custom Title", message: "Custom message", actions: {
-                DialogButton.destructive("Delete") {
-                    print("Delete action")
-                }
-                DialogButton.cancel("Cancel")
-            })
-        }
+        let dialog = DialogStatus(dialog: AlertDialog {
+            DialogTitle("Custom Title")
+            DialogMessage("Custom message")
+            DialogButton(title: "Delete", role: .destructive) {
+                print("Delete action")
+            }
+            DialogButton(title: "Cancel", role: .cancel)
+        })
 
         #expect(dialog.status != .dismissed)
 
@@ -322,13 +303,12 @@ extension DialogType {
 
     @MainActor
     @Test func toastWithContentAndActions() {
-        let dialog = DialogStatus(style: .toast()) {
-            DialogContent(title: "Toast Title", message: "Toast message", actions: {
-                DialogButton.default("Action") {
-                    print("Toast action")
-                }
-            })
-        }
+        let dialog = DialogStatus(dialog: Toast {
+            DialogMessage("Toast message")
+            DialogButton(title: "Action") {
+                print("Toast action")
+            }
+        })
 
         if case .presented(let dialogType) = dialog.status {
             if case .toast = dialogType.style {
@@ -366,14 +346,10 @@ extension DialogType {
         let store = await TestStore(initial: AppState())
         
         // Register a toast with long duration (won't auto-dismiss during test)
-        DialogRegistry.register(id: FormWithDialog.DialogId.toastDialog) {
-            DialogCustomType.custom(
-                content: DialogContent(
-                    title: "Manual dismiss test",
-                    message: "This should be manually dismissed"
-                ),
-                style: .toast(ToastConfiguration(defaultDuration: 10.0)) // 10 seconds
-            )
+        await Dialog.register(id: FormWithDialog.DialogId.toastDialog) {
+            Toast(config: .init(defaultDuration: 10.0)) {
+                DialogMessage("This toast should be manually dismissed")
+            }
         }
         
         // Present the toast
@@ -394,14 +370,10 @@ extension DialogType {
         let store = await TestStore(initial: AppState())
         
         // Register a toast with zero duration (manual dismiss only)
-        DialogRegistry.register(id: FormWithDialog.DialogId.toastDialog) {
-            DialogCustomType.custom(
-                content: DialogContent(
-                    title: "Persistent toast",
-                    message: "This should not auto-dismiss"
-                ),
-                style: .toast(ToastConfiguration(defaultDuration: 0)) // No auto-dismiss
-            )
+        await Dialog.register(id: FormWithDialog.DialogId.toastDialog) {
+            Toast(config: .init(defaultDuration: 0)) {
+                DialogMessage("This toast should not auto-dismiss")
+            }
         }
         
         // Present the toast
@@ -417,6 +389,7 @@ extension DialogType {
     }
 
     // MARK: - Registry Tests
+    @MainActor
     @Test func registryBehavior() {
         let testId = "test-dialog"
 
@@ -425,7 +398,7 @@ extension DialogType {
         #expect(unregisteredDialog.status == .dismissed)
 
         // Register and test
-        DialogRegistry.register(id: testId) {
+        Dialog.register(id: testId) {
             DialogType.success(message: "Registered dialog", style: .toast())
         }
 

--- a/Tests/SwiftUI-UDF-Tests/Dialog/DialogTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/DialogTests.swift
@@ -237,18 +237,18 @@ extension DialogType {
         #expect(success)
 
         // Verify it's a toast with custom view
-        if case .presented(let dialogProtocol) = await store.state.form.dialog.status {
+        if case .presented(let dialogType) = await store.state.form.dialog.status {
             // Check style is toast
-            if case .toast(let config) = dialogProtocol.style {
+            if case .toast(let config) = dialogType.style {
                 #expect(config.position == .center)
             } else {
                 Issue.record("Expected toast style")
             }
 
             // Check custom view
-            #expect(!(dialogProtocol is DialogType))
+            #expect(!(dialogType is DialogType))
             await MainActor.run {
-                #expect(dialogProtocol.getCustomContentView() != nil)
+                #expect(dialogType.getCustomContentView() != nil)
             }
         } else {
             Issue.record("Expected custom dialog with custom view")

--- a/Tests/SwiftUI-UDF-Tests/Dialog/ToastDismissCallbackTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/ToastDismissCallbackTests.swift
@@ -52,7 +52,7 @@ import UDFSwiftTesting
     // MARK: - DialogRegistration Tests
 
     @MainActor
-    @Test func test_DialogRegistry_RegisterToast_WithOnAutoDismiss() {
+    @Test func test_DialogRegistry_RegisterToast_WithOnAutoDismiss() async {
         let testID = "test-toast-callback"
         let tracker = CallbackTracker()
 
@@ -64,6 +64,9 @@ import UDFSwiftTesting
         } onAutoDismiss: {
             tracker.executed = true
         }
+
+        // Wait for async barrier write to complete
+        await waitForMainActorCondition { Dialog.isRegistered(id: testID) }
 
         // Retrieve the registered toast
         let retrievedDialog = _DialogRegistry.get(id: testID)

--- a/Tests/SwiftUI-UDF-Tests/Dialog/ToastDismissCallbackTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/ToastDismissCallbackTests.swift
@@ -51,6 +51,7 @@ import UDFSwiftTesting
 
     // MARK: - DialogRegistration Tests
 
+    @MainActor
     @Test func test_DialogRegistry_RegisterToast_WithOnAutoDismiss() {
         let testID = "test-toast-callback"
         let tracker = CallbackTracker()
@@ -65,7 +66,7 @@ import UDFSwiftTesting
         }
 
         // Retrieve the registered toast
-        let retrievedDialog = DialogRegistry.get(id: testID)
+        let retrievedDialog = _DialogRegistry.get(id: testID)
         #expect(retrievedDialog != nil)
 
         // Verify it has the callback in configuration
@@ -82,9 +83,10 @@ import UDFSwiftTesting
         }
 
         // Clean up
-        DialogRegistry.unregister(id: testID)
+        Dialog.unregister(id: testID)
     }
 
+    @MainActor
     @Test func test_DialogRegistry_RegisterToast_WithoutOnAutoDismiss() {
         let testID = "test-toast-no-callback"
 
@@ -94,7 +96,7 @@ import UDFSwiftTesting
         }
 
         // Retrieve and verify no callback
-        let retrievedDialog = DialogRegistry.get(id: testID)
+        let retrievedDialog = _DialogRegistry.get(id: testID)
         if let customType = retrievedDialog as? DialogCustomType<EmptyView, EmptyView>,
            case .custom(_, let style) = customType,
            case .toast(let config) = style {
@@ -104,7 +106,7 @@ import UDFSwiftTesting
         }
 
         // Clean up
-        DialogRegistry.unregister(id: testID)
+        Dialog.unregister(id: testID)
     }
 
     // MARK: - ToastQueueManager Tests
@@ -118,8 +120,10 @@ import UDFSwiftTesting
             defaultDuration: 0.1,
             onAutoDismiss: { tracker.executed = true }
         )
-        let content = DialogContent("Test Toast")
-        let toast = DialogCustomType.custom(content: content, style: .toast(config))
+        
+        let toast = Toast(config: config) {
+            DialogMessage("Test Toast")
+        }
 
         queueManager.enqueue(toast)
 
@@ -142,8 +146,9 @@ import UDFSwiftTesting
             defaultDuration: 10.0, // Long duration
             onAutoDismiss: { tracker.executed = true }
         )
-        let content = DialogContent("Test Toast")
-        let toast = DialogCustomType.custom(content: content, style: .toast(config))
+        let toast = Toast(config: config) {
+            DialogMessage("Test Toast")
+        }
 
         queueManager.enqueue(toast)
 
@@ -170,8 +175,9 @@ import UDFSwiftTesting
             defaultDuration: 0, // No auto-dismiss
             onAutoDismiss: { tracker.executed = true }
         )
-        let content = DialogContent("Persistent Toast")
-        let toast = DialogCustomType.custom(content: content, style: .toast(config))
+        let toast = Toast(config: config) {
+            DialogMessage("Test Toast")
+        }
 
         queueManager.enqueue(toast)
 

--- a/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
@@ -78,7 +78,7 @@ import Foundation
         var success = await store.state.middlewareFlow == .loading
         #expect(success)
 
-        await store.wait(additionalSleepFor: 1.1)
+        await store.wait(additionalSleepFor: 2.0)
         success = await store.state.runForm.messagesCount > 0
         #expect(success)
 

--- a/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareTests.swift
@@ -606,7 +606,7 @@ private extension Actions {
                 case let action as Actions.CompleteTask:
                     // Add delay to simulate async work that can be cancelled
                     execute(
-                        DelayedUpdateEffect(title: "Completed: \(action.taskId)", delay: 0.1),
+                        DelayedUpdateEffect(title: "Completed: \(action.taskId)", delay: 0.5),
                         cancellation: "delayed_task"
                     )
                 default:

--- a/UDF/View/AlertBuilder/AlertBuilder.swift
+++ b/UDF/View/AlertBuilder/AlertBuilder.swift
@@ -132,7 +132,7 @@ public enum AlertBuilder {
     ///   - builder: A closure that returns an `AlertStyle`.
     @available(*, deprecated, message: "Use DialogRegistry.register(id:builder:) instead")
     public static func registerAlert(by id: some Hashable & Sendable, _ builder: @escaping @Sendable () -> AlertStyle) {
-        DialogRegistry.register(id: id) {
+        _DialogRegistry.register(id: id) {
             // Convert the AlertStyle to DialogType when accessed
             let alertStyle = builder()
             switch alertStyle.type {

--- a/UDF/View/Dialog/Content/AlertDialog.swift
+++ b/UDF/View/Dialog/Content/AlertDialog.swift
@@ -27,7 +27,7 @@ import SwiftUI
 ///     }
 /// }
 /// ```
-public struct AlertDialog: Dialog {
+public struct AlertDialog: DialogProtocol {
     public let payload: DialogPayload
     public let dialogStyle: DialogStyle = .alert
 

--- a/UDF/View/Dialog/Content/ConfirmationDialog.swift
+++ b/UDF/View/Dialog/Content/ConfirmationDialog.swift
@@ -27,7 +27,7 @@ import SwiftUI
 ///     }
 /// }
 /// ```
-public struct ConfirmationDialog: Dialog {
+public struct ConfirmationDialog: DialogProtocol {
     public let payload: DialogPayload
     public let dialogStyle: DialogStyle
 

--- a/UDF/View/Dialog/Content/Toast.swift
+++ b/UDF/View/Dialog/Content/Toast.swift
@@ -25,7 +25,7 @@ import SwiftUI
 ///     }
 /// }
 /// ```
-public struct Toast: Dialog {
+public struct Toast: DialogProtocol {
     public let payload: DialogPayload
     public let dialogStyle: DialogStyle
 

--- a/UDF/View/Dialog/Core/Dialog.swift
+++ b/UDF/View/Dialog/Core/Dialog.swift
@@ -16,6 +16,14 @@ public enum Dialog {}
 
 // MARK: - Registration
 public extension Dialog {
+    /// Registers a convenient standard dialog factory for a given identifier.
+    ///
+    /// The builder closure will be called each time the dialog is requested,
+    /// allowing for dynamic content based on current application state.
+    ///
+    /// - Parameters:
+    ///   - id: A unique identifier for the dialog. Can be any Hashable type.
+    ///   - builder: A closure that returns a dialog type when called.
     static func register<ID: Hashable & Sendable>(
         id: ID,
         builder: @escaping @Sendable () -> DialogType
@@ -23,6 +31,26 @@ public extension Dialog {
         _DialogRegistry.register(id: id, builder: builder)
     }
     
+    /// Registers a type-safe ``DialogProtocol`` (``AlertDialog``, ``Toast``, or ``ConfirmationDialog``)
+    /// for the given identifier.
+    ///
+    /// The `@MainActor` builder closure is evaluated eagerly at registration time
+    /// and the resulting ``DialogProtocol`` value — which is `Sendable` — is captured and
+    /// stored in the registry for later retrieval.
+    ///
+    /// ```swift
+    /// Dialog.register(id: MyDialogs.error) {
+    ///     AlertDialog {
+    ///         DialogTitle("Error")
+    ///         DialogMessage("Something went wrong.")
+    ///         DialogButton(title: "OK")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - id: A unique, hashable identifier for this dialog.
+    ///   - dialog: A closure that returns a ``DialogProtocol`` conforming value.
     @MainActor
     static func register<ID: Hashable & Sendable, D: DialogProtocol>(
         id: ID,
@@ -31,22 +59,44 @@ public extension Dialog {
         _DialogRegistry.register(id: id, dialog: dialog)
     }
     
+    /// Checks if a dialog is registered for the given identifier.
+    ///
+    /// - Parameter id: The identifier to check.
+    /// - Returns: True if a dialog is registered for this identifier.
     static func isRegistered<ID: Hashable>(id: ID) -> Bool {
         _DialogRegistry.isRegistered(id: id)
     }
     
+    /// Unregisters a dialog for the given identifier.
+    ///
+    /// After calling this function, attempts to create dialogs using
+    /// the specified identifier will result in a dismissed state.
+    ///
+    /// - Parameter id: The identifier of the dialog to unregister.
     static func unregister<ID: Hashable & Sendable>(id: ID) {
         _DialogRegistry.unregister(id: id)
     }
     
+    /// Clears all registered dialogs.
+    ///
+    /// This function removes all dialogs from the registry. It's primarily
+    /// useful for testing scenarios or application reset functionality.
     static func clearAll() {
         _DialogRegistry.clearAll()
     }
     
+    /// Returns the number of currently registered dialogs.
+    ///
+    /// - Returns: The count of registered dialogs.
     static func count() -> Int {
         _DialogRegistry.count()
     }
     
+    /// Returns all currently registered dialog identifiers.
+    ///
+    /// The returned identifiers are not guaranteed to be in any particular order.
+    ///
+    /// - Returns: An array of all registered dialog identifiers.
     static func identifiers() -> [AnyHashable] {
         _DialogRegistry.identifiers()
     }
@@ -54,6 +104,13 @@ public extension Dialog {
 
 // MARK: - Legacy
 public extension Dialog {
+    /// Convenience function for registering simple message dialogs.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier for the dialog.
+    ///   - category: The dialog category (success, error, warning, info).
+    ///   - message: The message to display.
+    ///   - style: The dialog style (defaults to .alert).
     @available(*, deprecated, message: "Use the new ResultBuilder-based register(id:dialog:) with AlertDialog, Toast, or ConfirmationDialog instead.")
     static func register<ID: Hashable & Sendable>(
         id: ID,
@@ -64,6 +121,17 @@ public extension Dialog {
         _DialogRegistry.register(id: id, category: category, message: message, style: style)
     }
     
+    /// Registers a toast dialog with custom content and configuration.
+    ///
+    /// This method provides a convenient way to register toast dialogs with
+    /// rich content and custom styling. Unlike alerts, toasts support theming,
+    /// positioning, and non-modal presentation.
+    ///
+    /// - Parameters:
+    ///   - id: A unique identifier for the toast.
+    ///   - content: The dialog content with title, message, and actions.
+    ///   - configuration: Toast-specific configuration for styling and behavior.
+    ///   - onAutoDismiss: Optional callback executed when toast auto-dismisses due to timer.
     @available(*, deprecated, message: "Use the new ResultBuilder-based register(id:dialog:) with Toast instead.")
     static func registerToast<ID: Hashable & Sendable>(
         id: ID,
@@ -79,6 +147,18 @@ public extension Dialog {
         )
     }
     
+    /// Registers a toast with custom SwiftUI content.
+    ///
+    /// This method allows registration of toasts with completely custom SwiftUI views,
+    /// providing maximum flexibility for rich notifications, progress indicators,
+    /// and interactive toast experiences.
+    ///
+    /// - Parameters:
+    ///   - id: A unique identifier for the toast.
+    ///   - title: The toast title.
+    ///   - customContent: A closure returning the custom SwiftUI content.
+    ///   - configuration: Toast configuration for styling and behavior.
+    ///   - onAutoDismiss: Optional callback executed when toast auto-dismisses due to timer.
     @available(*, deprecated, message: "Use the new ResultBuilder-based register(id:dialog:) with Toast and DialogView instead.")
     static func registerCustomToast<ID: Hashable & Sendable, CustomContent: View>(
         id: ID,

--- a/UDF/View/Dialog/Core/Dialog.swift
+++ b/UDF/View/Dialog/Core/Dialog.swift
@@ -14,12 +14,11 @@ import SwiftUI
 /// A namespace for dialog registration and management.
 public enum Dialog {}
 
-// MARK: Registration
+// MARK: - Registration
 public extension Dialog {
-    @available(*, deprecated, message: "Use the new ResultBuilder-based register(id:dialog:) with AlertDialog, Toast, or ConfirmationDialog instead.")
     static func register<ID: Hashable & Sendable>(
         id: ID,
-        builder: @escaping @Sendable () -> any DialogTypeProtocol
+        builder: @escaping @Sendable () -> DialogType
     ) {
         _DialogRegistry.register(id: id, builder: builder)
     }
@@ -51,7 +50,10 @@ public extension Dialog {
     static func identifiers() -> [AnyHashable] {
         _DialogRegistry.identifiers()
     }
-    
+}
+
+// MARK: - Legacy
+public extension Dialog {
     @available(*, deprecated, message: "Use the new ResultBuilder-based register(id:dialog:) with AlertDialog, Toast, or ConfirmationDialog instead.")
     static func register<ID: Hashable & Sendable>(
         id: ID,

--- a/UDF/View/Dialog/Core/Dialog.swift
+++ b/UDF/View/Dialog/Core/Dialog.swift
@@ -1,0 +1,96 @@
+//===--- Dialog.swift ----------------------------------------------------===//
+//
+// This source file is part of the UDF open source project
+//
+// Copyright (c) 2026 You are launched
+// Licensed under Apache License v2.0
+//
+// See https://opensource.org/licenses/Apache-2.0 for license information
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftUI
+
+/// A namespace for dialog registration and management.
+public enum Dialog {}
+
+// MARK: Registration
+public extension Dialog {
+    @available(*, deprecated, message: "Use the new ResultBuilder-based register(id:dialog:) with AlertDialog, Toast, or ConfirmationDialog instead.")
+    static func register<ID: Hashable & Sendable>(
+        id: ID,
+        builder: @escaping @Sendable () -> any DialogTypeProtocol
+    ) {
+        _DialogRegistry.register(id: id, builder: builder)
+    }
+    
+    @MainActor
+    static func register<ID: Hashable & Sendable, D: DialogProtocol>(
+        id: ID,
+        dialog: @escaping @Sendable @MainActor () -> D
+    ) {
+        _DialogRegistry.register(id: id, dialog: dialog)
+    }
+    
+    static func isRegistered<ID: Hashable>(id: ID) -> Bool {
+        _DialogRegistry.isRegistered(id: id)
+    }
+    
+    static func unregister<ID: Hashable & Sendable>(id: ID) {
+        _DialogRegistry.unregister(id: id)
+    }
+    
+    static func clearAll() {
+        _DialogRegistry.clearAll()
+    }
+    
+    static func count() -> Int {
+        _DialogRegistry.count()
+    }
+    
+    static func identifiers() -> [AnyHashable] {
+        _DialogRegistry.identifiers()
+    }
+    
+    @available(*, deprecated, message: "Use the new ResultBuilder-based register(id:dialog:) with AlertDialog, Toast, or ConfirmationDialog instead.")
+    static func register<ID: Hashable & Sendable>(
+        id: ID,
+        category: DialogCategory,
+        message: String,
+        style: DialogStyle = .alert
+    ) {
+        _DialogRegistry.register(id: id, category: category, message: message, style: style)
+    }
+    
+    @available(*, deprecated, message: "Use the new ResultBuilder-based register(id:dialog:) with Toast instead.")
+    static func registerToast<ID: Hashable & Sendable>(
+        id: ID,
+        content: @escaping @Sendable () -> DialogContent<EmptyView, EmptyView>,
+        configuration: @escaping @Sendable () -> ToastConfiguration = { .default },
+        onAutoDismiss: (@Sendable () -> Void)? = nil
+    ) {
+        _DialogRegistry.registerToast(
+            id: id,
+            content: content,
+            configuration: configuration,
+            onAutoDismiss: onAutoDismiss
+        )
+    }
+    
+    @available(*, deprecated, message: "Use the new ResultBuilder-based register(id:dialog:) with Toast and DialogView instead.")
+    static func registerCustomToast<ID: Hashable & Sendable, CustomContent: View>(
+        id: ID,
+        title: String,
+        customContent: @escaping @Sendable () -> CustomContent,
+        configuration: @escaping @Sendable () -> ToastConfiguration = { .default },
+        onAutoDismiss: (@Sendable () -> Void)? = nil
+    ) {
+        _DialogRegistry.registerCustomToast(
+            id: id,
+            title: title,
+            customContent: customContent,
+            configuration: configuration,
+            onAutoDismiss: onAutoDismiss
+        )
+    }
+}

--- a/UDF/View/Dialog/Core/DialogRegistration.swift
+++ b/UDF/View/Dialog/Core/DialogRegistration.swift
@@ -12,6 +12,9 @@
 import Foundation
 import SwiftUI
 
+@available(*, deprecated, renamed: "Dialog")
+public typealias DialogRegistry = Dialog
+
 /// Registration system for reusable dialogs.
 ///
 /// The dialog registration system allows you to pre-define dialogs
@@ -39,7 +42,7 @@ import SwiftUI
 ///     // Use it
 /// }
 /// ```
-public enum DialogRegistry {
+enum _DialogRegistry {
     
     // MARK: - Private Storage
     
@@ -109,7 +112,7 @@ public enum DialogRegistry {
     ///   - id: A unique, hashable identifier for this dialog.
     ///   - dialog: A closure that returns a ``Dialog`` conforming value.
     @MainActor
-    public static func register<ID: Hashable & Sendable, D: Dialog>(
+    public static func register<ID: Hashable & Sendable, D: DialogProtocol>(
         id: ID,
         dialog: @escaping @Sendable @MainActor () -> D
     ) {
@@ -258,7 +261,7 @@ public enum DialogRegistry {
 /// This extension provides convenient methods for registering toast dialogs
 /// with common configurations and patterns. Toasts are non-modal dialogs
 /// that appear as overlay notifications.
-public extension DialogRegistry {
+extension _DialogRegistry {
     
     /// Registers a toast dialog with custom content and configuration.
     ///

--- a/UDF/View/Dialog/Core/DialogRegistration.swift
+++ b/UDF/View/Dialog/Core/DialogRegistration.swift
@@ -12,6 +12,7 @@
 import Foundation
 import SwiftUI
 
+/// Legacy typealias for the dialog component namespace.
 @available(*, deprecated, renamed: "Dialog")
 public typealias DialogRegistry = Dialog
 
@@ -30,7 +31,7 @@ public typealias DialogRegistry = Dialog
 /// ## Usage:
 /// ```swift
 /// // Register a dialog
-/// DialogRegistry.register(id: "networkError") {
+/// Dialog.register(id: "networkError") {
 ///     .error("No internet connection", style: .alert)
 /// }
 /// 
@@ -38,7 +39,7 @@ public typealias DialogRegistry = Dialog
 /// dialog = .init(id: "networkError")
 ///
 /// // Check if registered
-/// if DialogRegistry.isRegistered(id: "networkError") {
+/// if Dialog.isRegistered(id: "networkError") {
 ///     // Use it
 /// }
 /// ```
@@ -71,7 +72,7 @@ enum _DialogRegistry {
     ///
     /// ## Example:
     /// ```swift
-    /// DialogRegistry.register(id: "deleteConfirmation") {
+    /// Dialog.register(id: "deleteConfirmation") {
     ///     DialogCustomType.custom(
     ///         content: DialogContent("Delete Item", message: "This cannot be undone") {
     ///             DialogButton.destructive("Delete") { performDelete() }
@@ -91,6 +92,14 @@ enum _DialogRegistry {
         }
     }
     
+    /// Registers a convenient standard dialog factory for a given identifier.
+    ///
+    /// This registration overload is optimized for standard ``DialogType`` instances
+    /// representing simple `.success`, `.error`, `.warning`, or `.info` states.
+    ///
+    /// - Parameters:
+    ///   - id: A unique identifier for the dialog. Can be any Hashable type.
+    ///   - builder: A closure that returns a standard ``DialogType`` when called.
     public static func register<ID: Hashable & Sendable>(
         id: ID,
         builder: @escaping @Sendable () -> DialogType
@@ -108,7 +117,7 @@ enum _DialogRegistry {
     /// stored in the registry for later retrieval.
     ///
     /// ```swift
-    /// DialogRegistration.register(id: MyDialogs.error) {
+    /// Dialog.register(id: MyDialogs.error) {
     ///     AlertDialog {
     ///         DialogTitle("Error")
     ///         DialogMessage("Something went wrong.")
@@ -155,7 +164,7 @@ enum _DialogRegistry {
     ///
     /// ## Example:
     /// ```swift
-    /// if DialogRegistry.isRegistered(id: "networkError") {
+    /// if Dialog.isRegistered(id: "networkError") {
     ///     dialog = .init(id: "networkError")
     /// } else {
     ///     dialog = .init(error: "Unknown error occurred")
@@ -176,7 +185,7 @@ enum _DialogRegistry {
     ///
     /// ## Example:
     /// ```swift
-    /// DialogRegistry.unregister(id: "temporaryPromotion")
+    /// Dialog.unregister(id: "temporaryPromotion")
     /// ```
     public static func unregister<ID: Hashable & Sendable>(id: ID) {
         queue.async(flags: .barrier) {
@@ -196,7 +205,7 @@ enum _DialogRegistry {
     /// ## Example:
     /// ```swift
     /// // In test teardown
-    /// DialogRegistry.clearAll()
+    /// Dialog.clearAll()
     /// ```
     public static func clearAll() {
         queue.async(flags: .barrier) {
@@ -265,7 +274,7 @@ enum _DialogRegistry {
 
 // MARK: - ToastRegistry Extension
 
-/// Toast-specific registration extensions for `DialogRegistry`.
+/// Toast-specific registration extensions for `_DialogRegistry`.
 ///
 /// This extension provides convenient methods for registering toast dialogs
 /// with common configurations and patterns. Toasts are non-modal dialogs
@@ -286,7 +295,7 @@ extension _DialogRegistry {
     ///
     /// ## Example:
     /// ```swift
-    /// DialogRegistry.registerToast(id: "uploadProgress") {
+    /// Dialog.registerToast(id: "uploadProgress") {
     ///     DialogContent(
     ///         title: "Uploading File",
     ///         actions: {
@@ -341,7 +350,7 @@ extension _DialogRegistry {
     ///
     /// ## Example:
     /// ```swift
-    /// DialogRegistry.registerCustomToast(id: "downloadProgress", title: "Downloading") {
+    /// Dialog.registerCustomToast(id: "downloadProgress", title: "Downloading") {
     ///     VStack(spacing: 8) {
     ///         ProgressView(value: downloadProgress)
     ///         Text("\(Int(downloadProgress * 100))% complete")

--- a/UDF/View/Dialog/Core/DialogRegistration.swift
+++ b/UDF/View/Dialog/Core/DialogRegistration.swift
@@ -91,6 +91,15 @@ enum _DialogRegistry {
         }
     }
     
+    public static func register<ID: Hashable & Sendable>(
+        id: ID,
+        builder: @escaping @Sendable () -> DialogType
+    ) {
+        queue.async(flags: .barrier) {
+            registry[AnyHashable(id)] = builder
+        }
+    }
+    
     /// Registers a type-safe ``Dialog`` (``AlertDialog``, ``Toast``, or ``ConfirmationDialog``)
     /// for the given identifier.
     ///

--- a/UDF/View/Dialog/Core/DialogStatus.swift
+++ b/UDF/View/Dialog/Core/DialogStatus.swift
@@ -268,7 +268,7 @@ public struct DialogStatus: Equatable, Identifiable, Sendable {
     /// dialog = .init(id: "networkError")
     /// ```
     public init(id: some Hashable) {
-        if let dialog = DialogRegistry.get(id: id) {
+        if let dialog = _DialogRegistry.get(id: id) {
             self = .init(dialog: dialog)
         } else {
             self = .dismissed

--- a/UDF/View/Dialog/Core/Protocols/DialogProtocol.swift
+++ b/UDF/View/Dialog/Core/Protocols/DialogProtocol.swift
@@ -11,13 +11,13 @@
 
 import SwiftUI
 
-/// A protocol representing a type-safe dialog that can be registered with ``DialogRegistry``.
+/// A protocol representing a type-safe dialog that can be registered with ``Dialog``.
 ///
 /// Concrete conforming types — ``AlertDialog``, ``Toast``, and ``ConfirmationDialog`` —
 /// each use a dedicated result builder to ensure only valid components are accepted
 /// at compile time, producing clear error messages for unsupported usage.
 ///
-/// `Dialog` extends ``DialogTypeProtocol`` directly, meaning each conforming type
+/// `DialogProtocol` extends ``DialogTypeProtocol`` directly, meaning each conforming type
 /// is a first-class dialog type that the presentation layer can consume without
 /// any intermediate conversion through `DialogCustomType` or `DialogContent`.
 ///

--- a/UDF/View/Dialog/Core/Protocols/DialogProtocol.swift
+++ b/UDF/View/Dialog/Core/Protocols/DialogProtocol.swift
@@ -1,4 +1,4 @@
-//===--- Dialog.swift ----------------------------------------------------===//
+//===--- DialogProtocol.swift ----------------------------------------------------===//
 //
 // This source file is part of the UDF open source project
 //
@@ -31,7 +31,7 @@ import SwiftUI
 /// | ``AlertDialog``         | ``AlertDialogComponentBuilder``      | `.alert`               |
 /// | ``Toast``              | ``ToastComponentBuilder``            | `.toast(config)`       |
 /// | ``ConfirmationDialog`` | ``ConfirmationDialogComponentBuilder``| `.confirmationDialog`  |
-public protocol Dialog: DialogTypeProtocol {
+public protocol DialogProtocol: DialogTypeProtocol {
     /// The parsed dialog components produced by the result builder.
     var payload: DialogPayload { get }
 
@@ -40,7 +40,7 @@ public protocol Dialog: DialogTypeProtocol {
 }
 
 // MARK: - Default DialogTypeProtocol conformance
-extension Dialog {
+extension DialogProtocol {
     public var style: DialogStyle { dialogStyle }
     public var title: String { payload.title() }
     public var message: String? { payload.message() }
@@ -59,7 +59,7 @@ extension Dialog {
 }
 
 // MARK: - Equatable & Hashable
-extension Dialog {
+extension DialogProtocol {
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.title == rhs.title &&
         lhs.message == rhs.message &&


### PR DESCRIPTION
### Description
This merge request hides the registry implementation behind a new public `Dialog` namespace, so consumers no longer interact with `DialogRegistry` directly. The registry itself is renamed to `_DialogRegistry` and kept as the backing store, while registration, cleanup, and inspection APIs are exposed through `Dialog` static methods.

The change is necessary to make dialog management flow through the dialog-facing API instead of a separate registry type, matching the proposal’s goal of treating the registry as an internal detail. A compatibility path is preserved via `typealias DialogRegistry = Dialog`, but the implementation still directly references `_DialogRegistry` in framework internals and tests where retrieval is needed.

An additional structural change renames the public `Dialog` protocol to `DialogProtocol`, avoiding a naming collision with the new `Dialog` namespace. This enables concrete dialog types (`AlertDialog`, `Toast`, `ConfirmationDialog`) to continue exposing dialog behavior while letting `Dialog` become the public entry point for registration.

### Changes Made
- Introduced a new public namespace:
  ```swift
  public enum Dialog {}
  ```
  with public static APIs for:
  - `register(id:builder:)`
  - `register(id:dialog:)`
  - `isRegistered`
  - `unregister`
  - `clearAll`
  - `count`
  - `identifiers`

- Converted the old registry implementation into an internal detail:
  - `DialogRegistry` implementation renamed to `_DialogRegistry`
  - public compatibility kept via:
    ```swift
    @available(*, deprecated, renamed: "Dialog")
    public typealias DialogRegistry = Dialog
    ```

- Renamed the public dialog protocol to avoid collision with the new namespace:
  - `Dialog` protocol → `DialogProtocol`
  - `AlertDialog`, `Toast`, and `ConfirmationDialog` now conform to `DialogProtocol`

- Updated registration call sites in tests and usage examples from:
  ```swift
  DialogRegistry.register(...)
  ```
  to:
  ```swift
  Dialog.register(...)
  ```

- Adjusted internal retrieval paths to use `_DialogRegistry.get(id:)`, including `DialogStatus.init(id:)`, which keeps lookup internal while external callers use `Dialog` APIs.

- Refactored tests away from low-level `DialogCustomType` construction toward builder-based concrete dialogs:
  - alert tests now build `AlertDialog` directly
  - toast tests now build `Toast` directly
  - assertions inspect `Toast` payload/style instead of matching custom generic wrapper types

- Updated deprecated `AlertBuilder.registerAlert` to forward to `_DialogRegistry` directly, aligning it with the internalized registry design.

### Conclusion
Task completion mostly matches the proposal: public registration/management moved behind `Dialog`, and `DialogRegistry` is no longer the primary API.  
However, the result is not fully aligned with “all dialog-related interactions will go through `Dialog`”, because internal/tests still access `_DialogRegistry.get(id:)`, and retrieval was not exposed via `Dialog` extensions.

### ClickUp task
https://app.clickup.com/t/869cdbv18