### PR TITLE
Fix SwiftUI's transient view breaking onContainerDidUnload during the navigation reevaluation

### DIFF
--- a/UDF/View/Container/ConnectedContainer.swift
+++ b/UDF/View/Container/ConnectedContainer.swift
@@ -159,7 +159,10 @@ struct ConnectedContainer<C: Component, State: AppReducer>: View {
         containerLifecycle.set(didLoad: true, store: store)
         
         return C(props: map(store))
-            .onAppear { onContainerAppear(store) }
+            .onAppear {
+                containerLifecycle.markAsAppeared()
+                onContainerAppear(store)
+            }
             .onDisappear { onContainerDisappear(store) }
     }
 }

--- a/UDF/View/Container/ContainerLifecycle.swift
+++ b/UDF/View/Container/ContainerLifecycle.swift
@@ -38,7 +38,10 @@ import SwiftUI
 final class ContainerLifecycle<State: AppReducer>: ObservableObject {
     /// A private flag indicating if the container has completed its loading process.
     private var didLoad: Bool = false
-
+    
+    /// A private flag tracking if the container has physically appeared on screen
+    private var hasAppeared: Bool = false
+ 
     /// The hooks used within the container.
     let containerHooks: ContainerHooks<State>
 
@@ -51,8 +54,8 @@ final class ContainerLifecycle<State: AppReducer>: ObservableObject {
     /// Sets the `didLoad` state and executes the load command if the container loads for the first time.
     ///
     /// - Parameters:
-    ///   - didLoad: A Boolean indicating whether the container has completed its loading.
-    ///   - store: The global `EnvironmentStore` holding the state.
+    ///   - didLoad: A boolean value indicating whether the container has loaded.
+    ///   - store: The `EnvironmentStore` instance to use for executing the `didLoadCommand`.
     func set(didLoad: Bool, store: EnvironmentStore<State>) {
         if !self.didLoad, didLoad {
             containerHooks.createHooks()
@@ -61,8 +64,12 @@ final class ContainerLifecycle<State: AppReducer>: ObservableObject {
         self.didLoad = didLoad
     }
 
-    /// Initializes the `ContainerLifecycle` with commands to execute on load and unload,
-    /// and a closure to define hooks.
+    /// Marks the container as having physically appeared on screen at least once.
+    func markAsAppeared() {
+        hasAppeared = true
+    }
+
+    /// Initializes a new `ContainerLifecycle` instance with the specified load/unload commands and hooks.
     ///
     /// - Parameters:
     ///   - didLoadCommand: A command to execute when the container is first loaded.
@@ -81,6 +88,8 @@ final class ContainerLifecycle<State: AppReducer>: ObservableObject {
     /// Cleans up by removing all hooks and executing the unload command.
     deinit {
         containerHooks.removeAllHooks()
-        self.didUnloadCommand(EnvironmentStore<State>.global)
+        if hasAppeared {
+            self.didUnloadCommand(EnvironmentStore<State>.global)
+        }
     }
 }

--- a/UDF/View/Router/GlobalRouter/GlobalRoutingModifier.swift
+++ b/UDF/View/Router/GlobalRouter/GlobalRoutingModifier.swift
@@ -52,7 +52,7 @@ struct GlobalRoutingModifier<R: Routing>: ViewModifier where R.Route: Hashable {
             .navigationDestination(
                 for: R.Route.self,
                 destination: {
-                    R().view(for: $0)
+                    R().view(for: $0).id($0)
                 }
             )
     }


### PR DESCRIPTION
### Description
This merge request fixes container lifecycle behavior so unload logic is only executed for views that were actually presented on screen, and improves route rendering identity in global navigation.

Previously, `didUnloadCommand` could run during deinitialization even if the container never triggered `onAppear`, which could lead to premature cleanup or side effects for containers that were instantiated but never displayed. The new behavior separates “loaded” from “appeared”, ensuring teardown only happens after a real screen appearance.

In parallel, the global router now assigns a stable view identity based on the route value. This is necessary to avoid SwiftUI reusing navigation destination views incorrectly when navigating between routes of the same type.

An alternative would have been to keep unload tied to load state, but that would still treat initialization as equivalent to presentation, which is the root of the issue.

### Changes Made
- Added explicit appearance tracking to `ContainerLifecycle`:
  - introduced a new `hasAppeared` flag
  - added `markAsAppeared()` to record the first actual screen appearance

- Updated `ConnectedContainer` to mark the lifecycle as appeared inside `onAppear` before executing the existing appearance handler:
  ```swift
  .onAppear {
      containerLifecycle.markAsAppeared()
      onContainerAppear(store)
  }
  ```

- Changed container deinitialization behavior:
  - hooks are still removed unconditionally
  - `didUnloadCommand` now runs only if the container appeared at least once
  ```swift
  deinit {
      containerHooks.removeAllHooks()
      if hasAppeared {
          self.didUnloadCommand(EnvironmentStore<State>.global)
      }
  }
  ```

- Updated global navigation destination rendering to force route-based identity:
  ```swift
  R().view(for: $0).id($0)
  ```

- Minor documentation cleanup in `ContainerLifecycle` comments to better reflect the updated semantics.

### ClickUp task
https://app.clickup.com/t/869cv1atn