### PR TITLE
Fix crash when executing/canceling effect inside BaseMiddleware

### DIFF
--- a/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/ConcurrencyMiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/ConcurrencyMiddlewareCancellationTests.swift
@@ -62,6 +62,31 @@ import Foundation
         success = await waitForCondition { await store.state.middlewareFlow == .didCancel }
         #expect(success)
     }
+    
+    @Test func testMiddlewareCancellationDataRace() async {
+        let store = await TestStore(initial: AppState())
+        await store.subscribe(ObservableMiddlewareToCancel.self, environment: ObservableMiddlewareToCancel.Environment(loadItems: { [] }))
+
+        await store.dispatch(Actions.Loading())
+        var success = await waitForCondition { await store.state.middlewareFlow == .loading }
+        #expect(success)
+        
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<10 {
+                group.addTask {
+                    await store.dispatch(Actions.CancelLoading())
+                }
+            }
+        }
+        
+        let acceptableFlowState: [MiddlewareFlow] = [.cancel, .didCancel]
+        
+        success = await waitForCondition { acceptableFlowState.contains(await store.state.middlewareFlow) }
+        print(await store.state.middlewareFlow)
+        #expect(success)
+        
+        await store.wait()
+    }
 }
 
 private extension Actions {

--- a/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/ConcurrencyMiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/ConcurrencyMiddlewareCancellationTests.swift
@@ -82,7 +82,6 @@ import Foundation
         let acceptableFlowState: [MiddlewareFlow] = [.cancel, .didCancel]
         
         success = await waitForCondition { acceptableFlowState.contains(await store.state.middlewareFlow) }
-        print(await store.state.middlewareFlow)
         #expect(success)
         
         await store.wait()

--- a/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
@@ -117,7 +117,6 @@ import Foundation
         }
         let acceptableFlowState: [MiddlewareFlow] = [.none, .cancel]
         success = await waitForCondition { acceptableFlowState.contains(await store.state.middlewareFlow) }
-        print(await store.state.middlewareFlow)
         #expect(success)
         
         await store.wait()

--- a/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
@@ -100,6 +100,28 @@ import Foundation
         success = await waitForCondition { await store.state.middlewareFlow == .none }
         #expect(success)
     }
+    
+    @Test func testMiddlewareCancellationDataRace() async {
+        let store = await TestStore(initial: AppState())
+        await store.subscribe(ObservableMiddlewareToCancel.self, environment: ())
+        
+        await store.dispatch(Actions.Loading())
+        var success = await waitForCondition { await store.state.middlewareFlow == .loading }
+        #expect(success)
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<10 {
+                group.addTask {
+                    await store.dispatch(Actions.CancelLoading())
+                }
+            }
+        }
+        let acceptableFlowState: [MiddlewareFlow] = [.none, .cancel]
+        success = await waitForCondition { acceptableFlowState.contains(await store.state.middlewareFlow) }
+        print(await store.state.middlewareFlow)
+        #expect(success)
+        
+        await store.wait()
+    }
 }
 
 private extension Actions {

--- a/UDF/_Middleware/_BaseMiddleware.swift
+++ b/UDF/_Middleware/_BaseMiddleware.swift
@@ -65,8 +65,8 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
 
     /// A dictionary to track ongoing tasks by their unique identifiers, allowing for cancellation.
     public var cancellations: [AnyHashable: CancellableTask] {
-        return state.withLockUnchecked { state in
-            state.cancellations
+        cancellationsBox.withLockUnchecked { box in
+            box.cancellations
         }
     }
     
@@ -74,7 +74,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     ///
     /// This property ensures that operations on the internal data such as reading/writing—are
     /// atomic across different physical threads, preventing data races and memory corruption.
-    private let state = OSAllocatedUnfairLock(initialState: MutableState())
+    private let cancellationsBox = OSAllocatedUnfairLock(initialState: CancellationsBox())
 
     // MARK: - Cancellation
 
@@ -91,8 +91,8 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         }
 
         cancellableTask.cancel()
-        state.withLockUnchecked { state in
-            state.removeCancellation(forKey: anyId)
+        cancellationsBox.withLockUnchecked { box in
+            box.removeCancellation(forKey: anyId)
         }
         return true
     }
@@ -158,15 +158,15 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .receive(on: queue)
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
-                self?.state.withLockUnchecked { state in
-                    state.removeCancellation(forKey: anyId)
+                self?.cancellationsBox.withLockUnchecked { box in
+                    box.removeCancellation(forKey: anyId)
                 }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition)
             })
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations and signal Testing
-                self?.state.withLockUnchecked { state in
-                    state.removeCancellation(forKey: anyId)
+                self?.cancellationsBox.withLockUnchecked { box in
+                    box.removeCancellation(forKey: anyId)
                 }
             }, receiveValue: { [weak self] action in
                 // Handle receiving a value: Dispatch the action to the store
@@ -176,7 +176,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
                     TestGroup.instanceFor(key: testGroupKey).leave()
                 }
             })
-        state.withLockUnchecked { state in
+        cancellationsBox.withLockUnchecked { state in
             state.set(cancellable: cancellable, forKey: anyId)
         }
     }
@@ -265,8 +265,8 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .receive(on: queue)
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
-                self?.state.withLockUnchecked { state in
-                    state.removeCancellation(forKey: anyId)
+                self?.cancellationsBox.withLockUnchecked { box in
+                    box.removeCancellation(forKey: anyId)
                 }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition)
             })
@@ -285,8 +285,8 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             }
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations
-                self?.state.withLockUnchecked { state in
-                    state.removeCancellation(forKey: anyId)
+                self?.cancellationsBox.withLockUnchecked { box in
+                    box.removeCancellation(forKey: anyId)
                 }
                 TestGroup.instanceFor(key: testGroupKey).leave()
 
@@ -296,8 +296,8 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
                     self?.dispatch(action: mapAction(result.action), filePosition: filePosition)
                 }
             })
-        state.withLockUnchecked { state in
-            state.set(cancellable: cancellable, forKey: anyId)
+        cancellationsBox.withLockUnchecked { box in
+            box.set(cancellable: cancellable, forKey: anyId)
         }
     }
 
@@ -346,15 +346,15 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .receive(on: queue) // Specify the queue on which to receive events
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
-                self?.state.withLockUnchecked { state in
-                    state.removeCancellation(forKey: anyId)
+                self?.cancellationsBox.withLockUnchecked { box in
+                    box.removeCancellation(forKey: anyId)
                 }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition )
             })
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations
-                self?.state.withLockUnchecked { state in
-                    state.removeCancellation(forKey: anyId)
+                self?.cancellationsBox.withLockUnchecked { box in
+                    box.removeCancellation(forKey: anyId)
                 }
                 TestGroup.instanceFor(key: testGroupKey).leave()
 
@@ -365,8 +365,8 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
                     self?.dispatch(action: mapAction(action), filePosition: filePosition)
                 }
             })
-        state.withLockUnchecked { state in
-            state.set(cancellable: cancellable, forKey: anyId)
+        cancellationsBox.withLockUnchecked { box in
+            box.set(cancellable: cancellable, forKey: anyId)
         }
     }
 
@@ -498,14 +498,14 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             }
 
             // Remove the task from the cancellations dictionary
-            self?.state.withLockUnchecked { state in
-                state.removeCancellation(forKey: anyCancellationId)
+            self?.cancellationsBox.withLockUnchecked { box in
+                box.removeCancellation(forKey: anyCancellationId)
             }
         }
 
         // Store the task in the cancellations dictionary for future cancellation
-        state.withLockUnchecked { state in
-            state.set(cancellable: task, forKey: anyCancellationId)
+        cancellationsBox.withLockUnchecked { box in
+            box.set(cancellable: task, forKey: anyCancellationId)
         }
     }
     
@@ -513,7 +513,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     /// 
     /// This class enables the safe retrieval and cancellation of tasks across different threads,
     /// ensuring that internal storage is modified only through the established lock.
-    private class MutableState: @unchecked Sendable {
+    private class CancellationsBox: @unchecked Sendable {
         var cancellations: [AnyHashable: CancellableTask] = [:]
         
         func set(cancellable: CancellableTask, forKey key: AnyHashable) {

--- a/UDF/_Middleware/_BaseMiddleware.swift
+++ b/UDF/_Middleware/_BaseMiddleware.swift
@@ -11,6 +11,7 @@
 
 import Combine
 import Foundation
+import os
 
 /// `_BaseMiddleware` is an open class that serves as the base for creating middleware components
 /// in the UDF architecture. Middleware is responsible for handling side effects and can process actions
@@ -63,7 +64,18 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     public typealias ErrorMapper<Id> = @Sendable (_ id: Id, _ error: Error) -> any Action
 
     /// A dictionary to track ongoing tasks by their unique identifiers, allowing for cancellation.
-    public var cancellations: [AnyHashable: CancellableTask] = [:]
+    public var cancellations: [AnyHashable: CancellableTask] {
+        return state.withLockUnchecked { state in
+            state.cancellations
+        }
+    }
+    
+    /// Synchronizes access to the middleware's mutable state.
+    ///
+    /// This property ensures that operations on the internal dictionary—such as
+    /// adding, retrieving, or removing cancellation tasks—are atomic across different
+    /// physical threads, preventing data races and memory corruption.
+    private let state = OSAllocatedUnfairLock(initialState: MutableState())
 
     // MARK: - Cancellation
 
@@ -80,7 +92,9 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         }
 
         cancellableTask.cancel()
-        cancellations[anyId] = nil
+        state.withLockUnchecked { state in
+            state.deleteCancellation(forKey: anyId)
+        }
         return true
     }
 
@@ -140,17 +154,21 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         let testGroupKey = TestGroup.enter(for: store)
 
         // Subscribe to the effect and store the cancellation token
-        cancellations[anyId] = effect
+        let cancellable = effect
             .subscribe(on: queue)
             .receive(on: queue)
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
-                self?.cancellations[anyId] = nil
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyId)
+                }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition)
             })
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations and signal Testing
-                self?.cancellations[anyId] = nil
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyId)
+                }
             }, receiveValue: { [weak self] action in
                 // Handle receiving a value: Dispatch the action to the store
                 if self?.cancellations[anyId] != nil {
@@ -159,6 +177,9 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
                     TestGroup.instanceFor(key: testGroupKey).leave()
                 }
             })
+        state.withLockUnchecked { state in
+            state.set(cancellable: cancellable, forKey: anyId)
+        }
     }
 
     /// Executes an effect that conforms to both `PureEffect` and `ErasableToEffect` and dispatches actions to the store.
@@ -240,12 +261,14 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         let testGroupKey = TestGroup.instanceKey(store)
 
         // Subscribe to the effect and store the cancellation token
-        cancellations[anyId] = effect
+        let cancellable = effect
             .subscribe(on: queue)
             .receive(on: queue)
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
-                self?.cancellations[anyId] = nil
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyId)
+                }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition)
             })
             .flatMap { [weak self] action in
@@ -263,7 +286,9 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             }
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations
-                self?.cancellations[anyId] = nil
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyId)
+                }
                 TestGroup.instanceFor(key: testGroupKey).leave()
 
             }, receiveValue: { [weak self] result in
@@ -272,6 +297,9 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
                     self?.dispatch(action: mapAction(result.action), filePosition: filePosition)
                 }
             })
+        state.withLockUnchecked { state in
+            state.set(cancellable: cancellable, forKey: anyId)
+        }
     }
 
     /// Runs a `PureEffect` and dispatches its actions to the store.
@@ -314,17 +342,21 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         let testGroupKey = TestGroup.instanceKey(store)
 
         // Subscribe to the effect and store the cancellation token
-        cancellations[anyId] = effect
+        let cancellable = effect
             .subscribe(on: queue) // Subscribe to the effect on the specified queue
             .receive(on: queue) // Specify the queue on which to receive events
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
-                self?.cancellations[anyId] = nil
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyId)
+                }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition )
             })
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations
-                self?.cancellations[anyId] = nil
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyId)
+                }
                 TestGroup.instanceFor(key: testGroupKey).leave()
 
             }, receiveValue: { [weak self] action in
@@ -334,6 +366,9 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
                     self?.dispatch(action: mapAction(action), filePosition: filePosition)
                 }
             })
+        state.withLockUnchecked { state in
+            state.set(cancellable: cancellable, forKey: anyId)
+        }
     }
 
     // MARK: - Concurrency
@@ -465,12 +500,32 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
 
             // Remove the task from the cancellations dictionary
             _ = self?.queue.sync { [weak self] in
-                self?.cancellations.removeValue(forKey: anyCancellationId)
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyCancellationId)
+                }
             }
         }
 
         // Store the task in the cancellations dictionary for future cancellation
-        cancellations[anyCancellationId] = task
+        state.withLockUnchecked { state in
+            state.set(cancellable: task, forKey: anyCancellationId)
+        }
+    }
+    
+    /// A container for the middleware's mutable state, designed to be managed by a synchronization mechanism
+    /// 
+    /// This class enables the safe retrieval and cancellation of tasks across different threads,
+    /// ensuring that internal storage is modified only through the established lock.
+    private class MutableState: @unchecked Sendable {
+        var cancellations: [AnyHashable: CancellableTask] = [:]
+        
+        func set(cancellable: CancellableTask, forKey key: AnyHashable) {
+            cancellations[key] = cancellable
+        }
+        
+        func deleteCancellation(forKey key: AnyHashable) {
+            cancellations.removeValue(forKey: key)
+        }
     }
 }
 

--- a/UDF/_Middleware/_BaseMiddleware.swift
+++ b/UDF/_Middleware/_BaseMiddleware.swift
@@ -72,9 +72,8 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     
     /// Synchronizes access to the middleware's mutable state.
     ///
-    /// This property ensures that operations on the internal dictionary—such as
-    /// adding, retrieving, or removing cancellation tasks—are atomic across different
-    /// physical threads, preventing data races and memory corruption.
+    /// This property ensures that operations on the internal data such as reading/writing—are
+    /// atomic across different physical threads, preventing data races and memory corruption.
     private let state = OSAllocatedUnfairLock(initialState: MutableState())
 
     // MARK: - Cancellation

--- a/UDF/_Middleware/_BaseMiddleware.swift
+++ b/UDF/_Middleware/_BaseMiddleware.swift
@@ -92,7 +92,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
 
         cancellableTask.cancel()
         state.withLockUnchecked { state in
-            state.deleteCancellation(forKey: anyId)
+            state.removeCancellation(forKey: anyId)
         }
         return true
     }
@@ -159,14 +159,14 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
                 self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyId)
+                    state.removeCancellation(forKey: anyId)
                 }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition)
             })
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations and signal Testing
                 self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyId)
+                    state.removeCancellation(forKey: anyId)
                 }
             }, receiveValue: { [weak self] action in
                 // Handle receiving a value: Dispatch the action to the store
@@ -266,7 +266,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
                 self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyId)
+                    state.removeCancellation(forKey: anyId)
                 }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition)
             })
@@ -286,7 +286,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations
                 self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyId)
+                    state.removeCancellation(forKey: anyId)
                 }
                 TestGroup.instanceFor(key: testGroupKey).leave()
 
@@ -347,14 +347,14 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
                 self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyId)
+                    state.removeCancellation(forKey: anyId)
                 }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition )
             })
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations
                 self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyId)
+                    state.removeCancellation(forKey: anyId)
                 }
                 TestGroup.instanceFor(key: testGroupKey).leave()
 
@@ -498,10 +498,8 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             }
 
             // Remove the task from the cancellations dictionary
-            _ = self?.queue.sync { [weak self] in
-                self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyCancellationId)
-                }
+            self?.state.withLockUnchecked { state in
+                state.removeCancellation(forKey: anyCancellationId)
             }
         }
 
@@ -522,7 +520,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             cancellations[key] = cancellable
         }
         
-        func deleteCancellation(forKey key: AnyHashable) {
+        func removeCancellation(forKey key: AnyHashable) {
             cancellations.removeValue(forKey: key)
         }
     }


### PR DESCRIPTION
### Description
This merge request fixes a thread-safety issue in middleware cancellation handling. `_BaseMiddleware` was storing and mutating its `cancellations` dictionary from multiple execution contexts without synchronization, which could cause data races when several cancellation actions were dispatched at the same time.

The change is necessary because cancellation can be triggered concurrently from Combine pipelines and async tasks, and the middleware was marked `@unchecked Sendable` while still relying on unsynchronized mutable state. An alternative would have been to isolate cancellation state behind an actor or move all access onto a single serialized queue, but this MR keeps the current design and adds explicit locking around the shared mutable state.

### Changes Made
- Made middleware cancellation storage thread-safe by replacing direct access to:
  ```swift
  public var cancellations: [AnyHashable: CancellableTask] = [:]
  ```
  with lock-protected access backed by:
  ```swift
  private let state = OSAllocatedUnfairLock(initialState: MutableState())
  ```

- Introduced a private `MutableState` container to encapsulate the `cancellations` dictionary and provide controlled mutation helpers:
  - `set(cancellable:forKey:)`
  - `deleteCancellation(forKey:)`

- Updated all cancellation lifecycle paths in `_BaseMiddleware` to use the lock:
  - explicit cancellation via `cancel(by:)`
  - Combine `receiveCancel`
  - Combine completion handlers
  - async task completion / cleanup
  - storing newly created cancellables and tasks

- Preserved the public `cancellations` API as a computed property that now returns a lock-protected snapshot of the internal state.

- Added regression tests for concurrent cancellation in both middleware test suites:
  - `ConcurrencyMiddlewareCancellationTests.testMiddlewareCancellationDataRace`
  - `MiddlewareCancellationTests.testMiddlewareCancellationDataRace`

- The new tests dispatch `CancelLoading()` concurrently from multiple tasks and verify that middleware reaches one of the expected cancellation states without crashing or corrupting state.

### ClickUp task
https://app.clickup.com/t/869d0m455