### PR TITLE
Fix crash when executing/canceling effect inside BaseMiddleware

### DIFF
--- a/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/ConcurrencyMiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/ConcurrencyMiddlewareCancellationTests.swift
@@ -62,6 +62,31 @@ import Foundation
         success = await waitForCondition { await store.state.middlewareFlow == .didCancel }
         #expect(success)
     }
+    
+    @Test func testMiddlewareCancellationDataRace() async {
+        let store = await TestStore(initial: AppState())
+        await store.subscribe(ObservableMiddlewareToCancel.self, environment: ObservableMiddlewareToCancel.Environment(loadItems: { [] }))
+
+        await store.dispatch(Actions.Loading())
+        var success = await waitForCondition { await store.state.middlewareFlow == .loading }
+        #expect(success)
+        
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<10 {
+                group.addTask {
+                    await store.dispatch(Actions.CancelLoading())
+                }
+            }
+        }
+        
+        let acceptableFlowState: [MiddlewareFlow] = [.cancel, .didCancel]
+        
+        success = await waitForCondition { acceptableFlowState.contains(await store.state.middlewareFlow) }
+        print(await store.state.middlewareFlow)
+        #expect(success)
+        
+        await store.wait()
+    }
 }
 
 private extension Actions {

--- a/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/ConcurrencyMiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-ConcurrencyTests/Middlewares/ConcurrencyMiddlewareCancellationTests.swift
@@ -82,7 +82,6 @@ import Foundation
         let acceptableFlowState: [MiddlewareFlow] = [.cancel, .didCancel]
         
         success = await waitForCondition { acceptableFlowState.contains(await store.state.middlewareFlow) }
-        print(await store.state.middlewareFlow)
         #expect(success)
         
         await store.wait()

--- a/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
@@ -117,7 +117,6 @@ import Foundation
         }
         let acceptableFlowState: [MiddlewareFlow] = [.none, .cancel]
         success = await waitForCondition { acceptableFlowState.contains(await store.state.middlewareFlow) }
-        print(await store.state.middlewareFlow)
         #expect(success)
         
         await store.wait()

--- a/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
@@ -100,6 +100,28 @@ import Foundation
         success = await waitForCondition { await store.state.middlewareFlow == .none }
         #expect(success)
     }
+    
+    @Test func testMiddlewareCancellationDataRace() async {
+        let store = await TestStore(initial: AppState())
+        await store.subscribe(ObservableMiddlewareToCancel.self, environment: ())
+        
+        await store.dispatch(Actions.Loading())
+        var success = await waitForCondition { await store.state.middlewareFlow == .loading }
+        #expect(success)
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<10 {
+                group.addTask {
+                    await store.dispatch(Actions.CancelLoading())
+                }
+            }
+        }
+        let acceptableFlowState: [MiddlewareFlow] = [.none, .cancel]
+        success = await waitForCondition { acceptableFlowState.contains(await store.state.middlewareFlow) }
+        print(await store.state.middlewareFlow)
+        #expect(success)
+        
+        await store.wait()
+    }
 }
 
 private extension Actions {

--- a/UDF/_Middleware/_BaseMiddleware.swift
+++ b/UDF/_Middleware/_BaseMiddleware.swift
@@ -11,7 +11,6 @@
 
 import Combine
 import Foundation
-import os
 
 /// `_BaseMiddleware` is an open class that serves as the base for creating middleware components
 /// in the UDF architecture. Middleware is responsible for handling side effects and can process actions

--- a/UDF/_Middleware/_BaseMiddleware.swift
+++ b/UDF/_Middleware/_BaseMiddleware.swift
@@ -64,17 +64,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     public typealias ErrorMapper<Id> = @Sendable (_ id: Id, _ error: Error) -> any Action
 
     /// A dictionary to track ongoing tasks by their unique identifiers, allowing for cancellation.
-    public var cancellations: [AnyHashable: CancellableTask] {
-        return state.withLockUnchecked { state in
-            state.cancellations
-        }
-    }
-    
-    /// Synchronizes access to the middleware's mutable state.
-    ///
-    /// This property ensures that operations on the internal data such as reading/writing—are
-    /// atomic across different physical threads, preventing data races and memory corruption.
-    private let state = OSAllocatedUnfairLock(initialState: MutableState())
+    public var cancellations: [AnyHashable: CancellableTask] = [:]
 
     // MARK: - Cancellation
 
@@ -86,22 +76,20 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     open func cancel(by cancellation: some Hashable) -> Bool {
         let anyId = AnyHashable(cancellation)
 
-        guard let cancellableTask = cancellations[anyId] else {
+        guard cancellations[anyId] != nil else {
             return false
         }
 
-        cancellableTask.cancel()
-        state.withLockUnchecked { state in
-            state.removeCancellation(forKey: anyId)
+        queue.async(flags: .barrier) { [weak self] in
+            self?.cancellations.removeValue(forKey: anyId)?.cancel()
         }
         return true
     }
 
     /// Cancels all ongoing tasks tracked in the `cancellations` dictionary.
     open func cancelAll() {
-        let keys = Array(cancellations.keys)
-        for key in keys {
-            cancel(by: key)
+        cancellations.keys.forEach { cancelation in
+            cancel(by: cancelation)
         }
     }
 
@@ -158,16 +146,12 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .receive(on: queue)
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
-                self?.state.withLockUnchecked { state in
-                    state.removeCancellation(forKey: anyId)
-                }
+                self?.setTask(nil, for: anyId)
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition)
             })
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations and signal Testing
-                self?.state.withLockUnchecked { state in
-                    state.removeCancellation(forKey: anyId)
-                }
+                self?.setTask(nil, for: anyId)
             }, receiveValue: { [weak self] action in
                 // Handle receiving a value: Dispatch the action to the store
                 if self?.cancellations[anyId] != nil {
@@ -176,9 +160,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
                     TestGroup.instanceFor(key: testGroupKey).leave()
                 }
             })
-        state.withLockUnchecked { state in
-            state.set(cancellable: cancellable, forKey: anyId)
-        }
+        setTask(cancellable, for: anyId)
     }
 
     /// Executes an effect that conforms to both `PureEffect` and `ErasableToEffect` and dispatches actions to the store.
@@ -265,9 +247,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .receive(on: queue)
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
-                self?.state.withLockUnchecked { state in
-                    state.removeCancellation(forKey: anyId)
-                }
+                self?.setTask(nil, for: anyId)
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition)
             })
             .flatMap { [weak self] action in
@@ -285,9 +265,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             }
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations
-                self?.state.withLockUnchecked { state in
-                    state.removeCancellation(forKey: anyId)
-                }
+                self?.setTask(nil, for: anyId)
                 TestGroup.instanceFor(key: testGroupKey).leave()
 
             }, receiveValue: { [weak self] result in
@@ -296,9 +274,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
                     self?.dispatch(action: mapAction(result.action), filePosition: filePosition)
                 }
             })
-        state.withLockUnchecked { state in
-            state.set(cancellable: cancellable, forKey: anyId)
-        }
+        setTask(cancellable, for: anyId)
     }
 
     /// Runs a `PureEffect` and dispatches its actions to the store.
@@ -346,16 +322,12 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .receive(on: queue) // Specify the queue on which to receive events
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
-                self?.state.withLockUnchecked { state in
-                    state.removeCancellation(forKey: anyId)
-                }
+                self?.setTask(nil, for: anyId)
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition )
             })
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations
-                self?.state.withLockUnchecked { state in
-                    state.removeCancellation(forKey: anyId)
-                }
+                self?.setTask(nil, for: anyId)
                 TestGroup.instanceFor(key: testGroupKey).leave()
 
             }, receiveValue: { [weak self] action in
@@ -365,9 +337,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
                     self?.dispatch(action: mapAction(action), filePosition: filePosition)
                 }
             })
-        state.withLockUnchecked { state in
-            state.set(cancellable: cancellable, forKey: anyId)
-        }
+        setTask(cancellable, for: anyId)
     }
 
     // MARK: - Concurrency
@@ -498,30 +468,16 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             }
 
             // Remove the task from the cancellations dictionary
-            self?.state.withLockUnchecked { state in
-                state.removeCancellation(forKey: anyCancellationId)
-            }
+            self?.setTask(nil, for: anyCancellationId)
         }
 
         // Store the task in the cancellations dictionary for future cancellation
-        state.withLockUnchecked { state in
-            state.set(cancellable: task, forKey: anyCancellationId)
-        }
+        setTask(task, for: anyCancellationId)
     }
     
-    /// A container for the middleware's mutable state, designed to be managed by a synchronization mechanism
-    /// 
-    /// This class enables the safe retrieval and cancellation of tasks across different threads,
-    /// ensuring that internal storage is modified only through the established lock.
-    private class MutableState: @unchecked Sendable {
-        var cancellations: [AnyHashable: CancellableTask] = [:]
-        
-        func set(cancellable: CancellableTask, forKey key: AnyHashable) {
-            cancellations[key] = cancellable
-        }
-        
-        func removeCancellation(forKey key: AnyHashable) {
-            cancellations.removeValue(forKey: key)
+    private func setTask(_ task: CancellableTask?, for anyId: AnyHashable) {
+        queue.async(flags: .barrier) { [weak self] in
+            self?.cancellations[anyId] = task
         }
     }
 }

--- a/UDF/_Middleware/_BaseMiddleware.swift
+++ b/UDF/_Middleware/_BaseMiddleware.swift
@@ -11,6 +11,7 @@
 
 import Combine
 import Foundation
+import os
 
 /// `_BaseMiddleware` is an open class that serves as the base for creating middleware components
 /// in the UDF architecture. Middleware is responsible for handling side effects and can process actions
@@ -63,7 +64,18 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     public typealias ErrorMapper<Id> = @Sendable (_ id: Id, _ error: Error) -> any Action
 
     /// A dictionary to track ongoing tasks by their unique identifiers, allowing for cancellation.
-    public var cancellations: [AnyHashable: CancellableTask] = [:]
+    public var cancellations: [AnyHashable: CancellableTask] {
+        return state.withLockUnchecked { state in
+            state.cancellations
+        }
+    }
+    
+    /// Synchronizes access to the middleware's mutable state.
+    ///
+    /// This property ensures that operations on the internal dictionary—such as
+    /// adding, retrieving, or removing cancellation tasks—are atomic across different
+    /// physical threads, preventing data races and memory corruption.
+    private let state = OSAllocatedUnfairLock(initialState: MutableState())
 
     // MARK: - Cancellation
 
@@ -80,7 +92,9 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         }
 
         cancellableTask.cancel()
-        cancellations[anyId] = nil
+        state.withLockUnchecked { state in
+            state.deleteCancellation(forKey: anyId)
+        }
         return true
     }
 
@@ -140,17 +154,21 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         let testGroupKey = TestGroup.enter(for: store)
 
         // Subscribe to the effect and store the cancellation token
-        cancellations[anyId] = effect
+        let cancellable = effect
             .subscribe(on: queue)
             .receive(on: queue)
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
-                self?.cancellations[anyId] = nil
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyId)
+                }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition)
             })
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations and signal Testing
-                self?.cancellations[anyId] = nil
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyId)
+                }
             }, receiveValue: { [weak self] action in
                 // Handle receiving a value: Dispatch the action to the store
                 if self?.cancellations[anyId] != nil {
@@ -159,6 +177,9 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
                     TestGroup.instanceFor(key: testGroupKey).leave()
                 }
             })
+        state.withLockUnchecked { state in
+            state.set(cancellable: cancellable, forKey: anyId)
+        }
     }
 
     /// Executes an effect that conforms to both `PureEffect` and `ErasableToEffect` and dispatches actions to the store.
@@ -240,12 +261,14 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         let testGroupKey = TestGroup.instanceKey(store)
 
         // Subscribe to the effect and store the cancellation token
-        cancellations[anyId] = effect
+        let cancellable = effect
             .subscribe(on: queue)
             .receive(on: queue)
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
-                self?.cancellations[anyId] = nil
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyId)
+                }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition)
             })
             .flatMap { [weak self] action in
@@ -263,7 +286,9 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             }
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations
-                self?.cancellations[anyId] = nil
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyId)
+                }
                 TestGroup.instanceFor(key: testGroupKey).leave()
 
             }, receiveValue: { [weak self] result in
@@ -272,6 +297,9 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
                     self?.dispatch(action: mapAction(result.action), filePosition: filePosition)
                 }
             })
+        state.withLockUnchecked { state in
+            state.set(cancellable: cancellable, forKey: anyId)
+        }
     }
 
     /// Runs a `PureEffect` and dispatches its actions to the store.
@@ -314,17 +342,21 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         let testGroupKey = TestGroup.instanceKey(store)
 
         // Subscribe to the effect and store the cancellation token
-        cancellations[anyId] = effect
+        let cancellable = effect
             .subscribe(on: queue) // Subscribe to the effect on the specified queue
             .receive(on: queue) // Specify the queue on which to receive events
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
-                self?.cancellations[anyId] = nil
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyId)
+                }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition )
             })
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations
-                self?.cancellations[anyId] = nil
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyId)
+                }
                 TestGroup.instanceFor(key: testGroupKey).leave()
 
             }, receiveValue: { [weak self] action in
@@ -334,6 +366,9 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
                     self?.dispatch(action: mapAction(action), filePosition: filePosition)
                 }
             })
+        state.withLockUnchecked { state in
+            state.set(cancellable: cancellable, forKey: anyId)
+        }
     }
 
     // MARK: - Concurrency
@@ -465,12 +500,32 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
 
             // Remove the task from the cancellations dictionary
             _ = self?.queue.sync { [weak self] in
-                self?.cancellations.removeValue(forKey: anyCancellationId)
+                self?.state.withLockUnchecked { state in
+                    state.deleteCancellation(forKey: anyCancellationId)
+                }
             }
         }
 
         // Store the task in the cancellations dictionary for future cancellation
-        cancellations[anyCancellationId] = task
+        state.withLockUnchecked { state in
+            state.set(cancellable: task, forKey: anyCancellationId)
+        }
+    }
+    
+    /// A container for the middleware's mutable state, designed to be managed by a synchronization mechanism
+    /// 
+    /// This class enables the safe retrieval and cancellation of tasks across different threads,
+    /// ensuring that internal storage is modified only through the established lock.
+    private class MutableState: @unchecked Sendable {
+        var cancellations: [AnyHashable: CancellableTask] = [:]
+        
+        func set(cancellable: CancellableTask, forKey key: AnyHashable) {
+            cancellations[key] = cancellable
+        }
+        
+        func deleteCancellation(forKey key: AnyHashable) {
+            cancellations.removeValue(forKey: key)
+        }
     }
 }
 

--- a/UDF/_Middleware/_BaseMiddleware.swift
+++ b/UDF/_Middleware/_BaseMiddleware.swift
@@ -72,9 +72,8 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     
     /// Synchronizes access to the middleware's mutable state.
     ///
-    /// This property ensures that operations on the internal dictionary—such as
-    /// adding, retrieving, or removing cancellation tasks—are atomic across different
-    /// physical threads, preventing data races and memory corruption.
+    /// This property ensures that operations on the internal data such as reading/writing—are
+    /// atomic across different physical threads, preventing data races and memory corruption.
     private let state = OSAllocatedUnfairLock(initialState: MutableState())
 
     // MARK: - Cancellation

--- a/UDF/_Middleware/_BaseMiddleware.swift
+++ b/UDF/_Middleware/_BaseMiddleware.swift
@@ -22,7 +22,11 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     public var store: any Store<State>
 
     /// The dispatch queue used to execute asynchronous operations.
-    public var queue: DispatchQueue
+    public var queue: DispatchQueue {
+        didSet {
+            queue.setSpecific(key: queueKey, value: ())
+        }
+    }
 
     // MARK: - Initialization
 
@@ -34,6 +38,11 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     public required init(store: some Store<State>, queue: DispatchQueue) {
         self.store = store
         self.queue = queue
+        self.queue.setSpecific(key: queueKey, value: ())
+    }
+    
+    deinit {
+        queue.setSpecific(key: queueKey, value: nil)
     }
 
     // MARK: - Middleware Status
@@ -75,7 +84,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
     open func cancel(by cancellation: some Hashable) -> Bool {
         let anyId = AnyHashable(cancellation)
 
-        guard cancellations[anyId] != nil else {
+        guard isRunningTask(id: anyId) else {
             return false
         }
 
@@ -87,6 +96,11 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
 
     /// Cancels all ongoing tasks tracked in the `cancellations` dictionary.
     open func cancelAll() {
+        let cancellations = if isOnQueue {
+            self.cancellations
+        } else {
+            queue.sync { self.cancellations }
+        }
         cancellations.keys.forEach { cancelation in
             cancel(by: cancelation)
         }
@@ -129,7 +143,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         let anyId = AnyHashable(cancellation)
 
         // Prevent executing the effect if an effect with the same ID is already in progress
-        guard cancellations[anyId] == nil else {
+        guard !isRunningTask(id: anyId) else {
             return
         }
 
@@ -153,7 +167,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
                 self?.setTask(nil, for: anyId)
             }, receiveValue: { [weak self] action in
                 // Handle receiving a value: Dispatch the action to the store
-                if self?.cancellations[anyId] != nil {
+                if self?.isRunningTask(id: anyId) == true {
                     self?.dispatch(action: mapAction(action), filePosition: filePosition)
                 } else {
                     TestGroup.instanceFor(key: testGroupKey).leave()
@@ -232,7 +246,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         let anyId = AnyHashable(cancellation)
 
         // Prevent running the effect if an effect with the same ID is already in progress
-        guard cancellations[anyId] == nil else {
+        guard !isRunningTask(id: anyId) else {
             return
         }
 
@@ -269,7 +283,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
 
             }, receiveValue: { [weak self] result in
                 // Dispatch the action if the cancellation token exists and the dispatch filter returns true
-                if self?.cancellations[anyId] != nil, dispatchFilter(result.state, result.action) {
+                if self?.isRunningTask(id: anyId) == true, dispatchFilter(result.state, result.action) {
                     self?.dispatch(action: mapAction(result.action), filePosition: filePosition)
                 }
             })
@@ -307,7 +321,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         let anyId = AnyHashable(cancellation)
 
         // Prevent running the effect if an effect with the same ID is already in progress
-        guard cancellations[anyId] == nil else {
+        guard !isRunningTask(id: anyId) else {
             return
         }
 
@@ -331,7 +345,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
 
             }, receiveValue: { [weak self] action in
                 // Dispatch the mapped action to the store if the effect is still active
-                if self?.cancellations[anyId] != nil {
+                if self?.isRunningTask(id: anyId) == true {
                     TestGroup.instanceFor(key: testGroupKey).enter()
                     self?.dispatch(action: mapAction(action), filePosition: filePosition)
                 }
@@ -436,7 +450,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         let anyCancellationId = AnyHashable(cancellation)
 
         // Prevent running the effect if an effect with the same cancellation ID is already in progress
-        guard cancellations[anyCancellationId] == nil else {
+        guard !isRunningTask(id: anyCancellationId) else {
             return
         }
 
@@ -474,10 +488,29 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
         setTask(task, for: anyCancellationId)
     }
     
+    /// Stores/removes a cancellation task for the given identifier, ensuring thread safety.
     private func setTask(_ task: CancellableTask?, for anyId: AnyHashable) {
         queue.async(flags: .barrier) { [weak self] in
             self?.cancellations[anyId] = task
         }
+    }
+    
+    /// Returns `true` if a cancellation with the given `id` exists in `cancellations`, checking the queue to ensure thread safety.
+    private func isRunningTask(id: AnyHashable) -> Bool {
+        if isOnQueue {
+            return cancellations[id] != nil
+        }
+        return queue.sync {
+            cancellations[id] != nil
+        }
+    }
+    
+    /// Specific key used to identify `queue` between other queues.
+    private let queueKey = DispatchSpecificKey<Void>()
+    
+    /// Returns `true` if the caller is currently executing on `queue`.
+    private var isOnQueue: Bool {
+        DispatchQueue.getSpecific(key: queueKey) != nil
     }
 }
 

--- a/UDF/_Middleware/_BaseMiddleware.swift
+++ b/UDF/_Middleware/_BaseMiddleware.swift
@@ -92,7 +92,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
 
         cancellableTask.cancel()
         state.withLockUnchecked { state in
-            state.deleteCancellation(forKey: anyId)
+            state.removeCancellation(forKey: anyId)
         }
         return true
     }
@@ -159,14 +159,14 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
                 self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyId)
+                    state.removeCancellation(forKey: anyId)
                 }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition)
             })
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations and signal Testing
                 self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyId)
+                    state.removeCancellation(forKey: anyId)
                 }
             }, receiveValue: { [weak self] action in
                 // Handle receiving a value: Dispatch the action to the store
@@ -266,7 +266,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
                 self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyId)
+                    state.removeCancellation(forKey: anyId)
                 }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition)
             })
@@ -286,7 +286,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations
                 self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyId)
+                    state.removeCancellation(forKey: anyId)
                 }
                 TestGroup.instanceFor(key: testGroupKey).leave()
 
@@ -347,14 +347,14 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             .handleEvents(receiveCancel: { [weak self] in
                 // Handle cancellation: Remove the task from cancellations and dispatch cancellation action
                 self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyId)
+                    state.removeCancellation(forKey: anyId)
                 }
                 self?.dispatch(action: mapAction(Actions.DidCancelEffect(by: cancellation)), filePosition: filePosition )
             })
             .sink(receiveCompletion: { [weak self] _ in
                 // Handle completion: Remove the task from cancellations
                 self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyId)
+                    state.removeCancellation(forKey: anyId)
                 }
                 TestGroup.instanceFor(key: testGroupKey).leave()
 
@@ -498,10 +498,8 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             }
 
             // Remove the task from the cancellations dictionary
-            _ = self?.queue.sync { [weak self] in
-                self?.state.withLockUnchecked { state in
-                    state.deleteCancellation(forKey: anyCancellationId)
-                }
+            self?.state.withLockUnchecked { state in
+                state.removeCancellation(forKey: anyCancellationId)
             }
         }
 
@@ -522,7 +520,7 @@ open class _BaseMiddleware<State: AppReducer>: _Middleware, @unchecked Sendable 
             cancellations[key] = cancellable
         }
         
-        func deleteCancellation(forKey key: AnyHashable) {
+        func removeCancellation(forKey key: AnyHashable) {
             cancellations.removeValue(forKey: key)
         }
     }


### PR DESCRIPTION
### Description
This merge request fixes a race condition in middleware cancellation handling when multiple cancellation requests are dispatched at the same time.

The problem was that `_BaseMiddleware` accessed and mutated its internal `cancellations` storage from different execution paths without consistently serializing writes. Under concurrent `CancelLoading` dispatches, this could lead to unsafe dictionary access, inconsistent middleware state transitions, or cancellation callbacks racing with task removal.

The changes are necessary to make cancellation behavior deterministic enough under contention and to protect the middleware’s cancellation registry across both Combine-based effects and async task execution. An alternative would have been to isolate cancellation state behind an actor or a dedicated lock-based abstraction, but this MR keeps the current design and hardens it by routing updates through the existing queue with barrier writes.

### Changes Made
- Added regression tests for concurrent cancellation in both middleware implementations:
  - `ConcurrencyMiddlewareCancellationTests.testMiddlewareCancellationDataRace`
  - `MiddlewareCancellationTests.testMiddlewareCancellationDataRace`
- The new tests:
  - start a loading effect,
  - dispatch `CancelLoading` 10 times concurrently via `withTaskGroup`,
  - assert only race-tolerant end states (`.cancel` / `.didCancel` or `.none` / `.cancel` depending on implementation),
  - wait for store completion to ensure cancellation paths fully settle.

- Refactored `_BaseMiddleware` cancellation bookkeeping to avoid direct unsynchronized mutation of `cancellations`:
  - `cancel(by:)` now removes and cancels entries through a barrier block instead of reading and nil-ing inline.
  - `cancelAll()` now iterates current keys and delegates to `cancel(by:)`.
  - Introduced `setTask(_:for:)` to centralize task registration/removal using `queue.async(flags: .barrier)`.

- Updated all effect execution paths to use `setTask` instead of writing to `cancellations` directly:
  - initial effect subscription registration now stores the resulting cancellable/task through `setTask`
  - cancellation and completion handlers now clear tracked tasks through `setTask(nil, ...)`
  - async task cleanup also uses the same path

```swift
private func setTask(_ task: CancellableTask?, for anyId: AnyHashable) {
    queue.async(flags: .barrier) { [weak self] in
        self?.cancellations[anyId] = task
    }
}
```

- Result: cancellation tracking is now funneled through a single synchronized write mechanism, and the new tests cover the concurrent-dispatch scenario that previously exposed the race.
Synchronize cancellations using GCD mechanism to resolve data racing

### ClickUp task
https://app.clickup.com/t/869d0m455