### PR TITLE
Add backward compatibility for DialogRegistry.register (legacy code support)

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/Dialog/DialogTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/DialogTests.swift
@@ -94,6 +94,29 @@ extension DialogType {
     init() {
         Dialog.clearAll()
     }
+    
+    @Test func legacyDialogRegistration_allowsPresentationById() async {
+        let store = await TestStore(initial: AppState())
+        #expect(await store.state.form.dialog.status == .dismissed)
+        
+        await Dialog.register(id: FormWithDialog.DialogId.dialogWithAction) {
+            DialogCustomType.custom(
+                content: .init(
+                    title: "Custom Title",
+                    message: "Custom Desciprion",
+                    actions: {
+                        DialogButton(title: "Cancel")
+                        DialogButton(title: "Primary", role: .destructive)
+                    }
+                ),
+                style: .alert
+            )
+        }
+        await waitForCondition { Dialog.isRegistered(id: FormWithDialog.DialogId.dialogWithAction) }
+        await store.dispatch(Actions.PresentDialogWithAction())
+        let success = await waitForCondition { await store.state.form.dialog.status != .dismissed }
+        #expect(success)
+    }
 
     @Test func whendialogRegistered_dialogCanBePresentedById() async {
         let store = await TestStore(initial: AppState())

--- a/UDF/View/Dialog/Core/Protocols/DialogType.swift
+++ b/UDF/View/Dialog/Core/Protocols/DialogType.swift
@@ -94,6 +94,31 @@ public enum DialogCustomType<Icon: View, Content: View>: DialogTypeProtocol {
     }
 }
 
+extension DialogCustomType: DialogProtocol {
+    public var payload: DialogPayload {
+        let icon: @MainActor () -> AnyView = {
+            getIconView(theme: .default) ?? AnyView(EmptyView())
+        }
+        let content: @MainActor () -> AnyView = {
+            getCustomContentView() ?? AnyView(EmptyView())
+        }
+        let title: @Sendable () -> String = { [title] in title }
+        let message: @Sendable () -> String? = { [message] in message }
+        
+        return DialogPayload(
+            title: title,
+            message: message,
+            actions: actions,
+            icon: icon,
+            customContentView: content
+        )
+    }
+    
+    public var dialogStyle: DialogStyle {
+        style
+    }
+}
+
 /// Defines the type and content of a dialog.
 ///
 /// `DialogType` represents different categories of dialogs with their


### PR DESCRIPTION
### Description
This merge request restores compatibility with the legacy dialog registration flow for custom dialogs registered by ID.

The issue was that `DialogCustomType` could be created and registered, but it did not conform to `DialogProtocol`, which prevented the older registration/presentation path from treating it as a valid dialog payload. As a result, dialogs registered through the legacy API could fail to present even though they were successfully registered.

These changes are necessary to support existing code paths that still rely on ID-based registration, without forcing an immediate migration to newer dialog definitions. An alternative would have been to rewrite the legacy registration mechanism or require all callers to migrate, but this change keeps backward compatibility with minimal impact.

### Changes Made
- Added `DialogProtocol` conformance to `DialogCustomType`:
  - exposes `payload` by mapping its existing title, message, actions, icon, and custom content into `DialogPayload`
  - exposes `dialogStyle` by forwarding the existing `style`

```swift
extension DialogCustomType: DialogProtocol {
    public var payload: DialogPayload { ... }
    public var dialogStyle: DialogStyle { style }
}
```

- Added a regression test to verify that a dialog registered through the legacy `Dialog.register(id:)` API can still be presented by ID:
  - registers a `DialogCustomType.custom(...)`
  - waits for registration to complete
  - dispatches the presentation action
  - asserts that the dialog state changes from `.dismissed`

- The new test specifically covers the backward-compatibility path that was previously unverified.
Upgrading to v1.5.1-rc broke old code dialog registration. This forces a refactor of the dialog registration to align with the new style, so we have two option to solve the problem. Add confirmation DialogProtocol to DialogCustomType. The solution introduced in the pr. 

Another option is to add an additional method that accepts DialogTypeProtocol as a parameter:

```swift

  @MainActor
  static func register<ID: Hashable & Sendable, D: DialogTypeProtocol>(
      id: ID,
      builder: @escaping @Sendable () -> D
  ) {
      _DialogRegistry.register(id: id, builder: builder)
  }
```

### ClickUp task
https://app.clickup.com/t/869d3gbah