### PR TITLE
Add @ActionGroupBuilder overload to Store.dispatch

### DIFF
--- a/Tests/SwiftUI-UDF-ConcurrencyTests/ActionGroupBuilderDispatchTests.swift
+++ b/Tests/SwiftUI-UDF-ConcurrencyTests/ActionGroupBuilderDispatchTests.swift
@@ -32,10 +32,10 @@ import UDFSwiftTesting
     @Test func dispatchActionGroupBuilder_TestStore() async {
         let store = await TestStore(initial: AppState())
 
-        await store.dispatch(ActionGroup {
+        await store.dispatch {
             Actions.UpdateFormField(keyPath: \PlainForm.title, value: "test title")
             Actions.UpdateFormField(keyPath: \PlainForm.subtitle, value: "test subtitle")
-        })
+        }
 
         let title = await store.state.plainForm.title
         let subtitle = await store.state.plainForm.subtitle

--- a/Tests/SwiftUI-UDF-ConcurrencyTests/ActionGroupBuilderDispatchTests.swift
+++ b/Tests/SwiftUI-UDF-ConcurrencyTests/ActionGroupBuilderDispatchTests.swift
@@ -1,0 +1,88 @@
+//
+//  ActionGroupBuilderDispatchTests.swift
+//  SwiftUI-UDF
+//
+//  Created by Oleksandr Bodnar on 20.05.2026.
+//
+
+@testable import UDF
+import Testing
+import UDFSwiftTesting
+
+@Suite struct ActionGroupBuilderDispatchTests {
+    // MARK: - EnvironmentStore
+    @Test func dispatchActionGroupBuilder_EnvironmentStore() async {
+        let store = EnvironmentStore(initial: AppState(), loggers: [])
+
+        store.dispatch {
+            Actions.UpdateFormField(keyPath: \PlainForm.title, value: "env title")
+            Actions.UpdateFormField(keyPath: \PlainForm.subtitle, value: "env subtitle")
+        }
+
+        await waitForCondition {
+            store.state.plainForm.title == "env title" &&
+            store.state.plainForm.subtitle == "env subtitle"
+        }
+
+        #expect(store.state.plainForm.title == "env title")
+        #expect(store.state.plainForm.subtitle == "env subtitle")
+    }
+
+    // MARK: - TestStore
+    @Test func dispatchActionGroupBuilder_TestStore() async {
+        let store = await TestStore(initial: AppState())
+
+        await store.dispatch(ActionGroup {
+            Actions.UpdateFormField(keyPath: \PlainForm.title, value: "test title")
+            Actions.UpdateFormField(keyPath: \PlainForm.subtitle, value: "test subtitle")
+        })
+
+        let title = await store.state.plainForm.title
+        let subtitle = await store.state.plainForm.subtitle
+        #expect(title == "test title")
+        #expect(subtitle == "test subtitle")
+    }
+
+    // MARK: - Store from Middleware
+    @Test func dispatchActionGroupBuilder_StoreFromMiddleware() async {
+        let store = await TestStore(initial: AppState())
+        await store.subscribe { store in ActionGroupBuilderMiddleware(store: store) }
+
+        await store.dispatch(TriggerAction())
+        await store.wait()
+
+        let title = await store.state.plainForm.title
+        let subtitle = await store.state.plainForm.subtitle
+        #expect(title == "middleware title")
+        #expect(subtitle == "middleware subtitle")
+    }
+}
+
+private extension ActionGroupBuilderDispatchTests {
+    struct AppState: AppReducer {
+        var plainForm = PlainForm()
+    }
+
+    struct PlainForm: Form {
+        var title: String = ""
+        var subtitle: String = ""
+    }
+
+    struct TriggerAction: Action {}
+
+    final class ActionGroupBuilderMiddleware: Middleware<AppState>, @unchecked Sendable {
+        struct Environment {}
+        var environment: Environment!
+
+        static func buildLiveEnvironment(for store: some Store<AppState>) -> Environment { .init() }
+        static func buildTestEnvironment(for store: some Store<AppState>) -> Environment { .init() }
+
+        func reduce(_ action: some Action, for state: AppState) {
+            guard action is TriggerAction else { return }
+            store.dispatch {
+                Actions.UpdateFormField(keyPath: \PlainForm.title, value: "middleware title")
+                Actions.UpdateFormField(keyPath: \PlainForm.subtitle, value: "middleware subtitle")
+            }
+        }
+    }
+}

--- a/UDF/Store/EnvironmentStore+ActionGroupBuilder.swift
+++ b/UDF/Store/EnvironmentStore+ActionGroupBuilder.swift
@@ -1,0 +1,26 @@
+//
+//  EnvironmentStore+ActionGroupBuilder.swift
+//  SwiftUI-UDF
+//
+//  Created by Oleksandr Bodnar on 20.05.2026.
+//
+
+import Foundation
+
+public extension EnvironmentStore {
+    func dispatch(
+        priority: ActionPriority = .default,
+        fileName: String = #file,
+        functionName: String = #function,
+        lineNumber: Int = #line,
+        @ActionGroupBuilder _ builder: () -> ActionGroup
+    ) {
+        dispatch(
+            builder(),
+            priority: priority,
+            fileName: fileName,
+            functionName: functionName,
+            lineNumber: lineNumber
+        )
+    }
+}

--- a/UDF/Store/Store+ActionGroupBuilder.swift
+++ b/UDF/Store/Store+ActionGroupBuilder.swift
@@ -1,0 +1,26 @@
+//
+//  Store+ActionGroupBuilder.swift
+//  SwiftUI-UDF
+//
+//  Created by Oleksandr Bodnar on 20.05.2026.
+//
+
+import Foundation
+
+public extension Store {
+    nonisolated func dispatch(
+        priority: ActionPriority = .default,
+        fileName: String = #file,
+        functionName: String = #function,
+        lineNumber: Int = #line,
+        @ActionGroupBuilder _ builder: () -> ActionGroup
+    ) {
+        dispatch(
+            builder(),
+            priority: priority,
+            fileName: fileName,
+            functionName: functionName,
+            lineNumber: lineNumber
+        )
+    }
+}

--- a/UDF/Store/TestStore/TestStore.swift
+++ b/UDF/Store/TestStore/TestStore.swift
@@ -117,3 +117,14 @@ public extension TestStore {
         await self.dispatch(Actions._OnContainerDidUnLoad(containerType: containerType, id: id), fileName: fileName, functionName: functionName, lineNumber: lineNumber)
     }
 }
+
+public extension TestStore {
+    func dispatch(
+        fileName: String = #file,
+        functionName: String = #function,
+        lineNumber: Int = #line,
+        @ActionGroupBuilder _ builder: () -> ActionGroup
+    ) async {
+        await dispatch(builder(), fileName: fileName, functionName: functionName, lineNumber: lineNumber)
+    }
+}


### PR DESCRIPTION
### Description
This merge request adds a result-builder-based API for dispatching grouped actions from `Store`, making multi-action dispatch calls more concise and easier to read.

The change solves the awkwardness of having to explicitly construct an `ActionGroup` before dispatching it. By allowing callers to build the group inline, the API becomes closer to SwiftUI-style declarative syntax while preserving the existing dispatch metadata (`priority`, file, function, line).

An alternative approach would be to keep `ActionGroup` creation explicit at the call site, but that would make grouped dispatches more verbose and less ergonomic.

### Changes Made
- Added a new `Store` extension in `Store+ActionGroupBuilder.swift`.
- Introduced a new overload of `dispatch` that accepts an `@ActionGroupBuilder` closure:
  ```swift
  nonisolated func dispatch(
      priority: ActionPriority = .default,
      fileName: String = #file,
      functionName: String = #function,
      lineNumber: Int = #line,
      @ActionGroupBuilder _ builder: () -> ActionGroup
  )
  ```
- The new overload builds the `ActionGroup` inline and forwards it to the existing `dispatch` implementation, preserving:
  - action priority
  - source-location metadata for tracing/debugging
- Marked the API as `nonisolated`, keeping it aligned with the existing dispatch access pattern.