### PR TITLE
Implement Dialog inlining

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/Dialog/DialogDSLTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/DialogDSLTests.swift
@@ -263,7 +263,6 @@ extension DialogTests {
     }
     
     // MARK: - Dialog Protocol Conformance
-    
     @Test("Dialog category is always .custom for DSL types")
     func dialogCategoryIsAlwaysCustom() {
         let alert = AlertDialog {
@@ -352,7 +351,7 @@ extension DialogTests {
     func dialogStatusIntegrationWithDSLAlertDialog() {
         let id = 999
         
-        DialogRegistry.register(id: id) {
+        Dialog.register(id: id) {
             AlertDialog {
                 DialogTitle("Status AlertDialog")
                 DialogMessage("Integration test")
@@ -381,7 +380,7 @@ extension DialogTests {
     func dialogStatusIntegrationWithDSLToast() {
         let id = 998
         
-        DialogRegistry.register(id: id) {
+        Dialog.register(id: id) {
             Toast(config: .init(theme: .vibrant, position: .bottom)) {
                 DialogMessage("Saved!")
                 DialogIcon { Image(systemName: "checkmark") }
@@ -425,5 +424,104 @@ extension DialogTests {
         }
         
         #expect(_DialogRegistry.get(id: id)?.title == "Second")
+    }
+    
+    // MARK: - Direct DialogStatus(dialog:) Init
+    
+    @Test("DialogStatus can be created directly from an AlertDialog using the closure-based init")
+    func dialogStatusDirectInitWithAlertDialog() {
+        let status = DialogStatus {
+            AlertDialog {
+                DialogTitle("Direct Alert")
+                DialogMessage("Created without registry")
+                DialogButton(title: "OK", action: {})
+            }
+        }
+        
+        guard case .presented(let dialog) = status.status else {
+            Issue.record("Expected presented dialog")
+            return
+        }
+        
+        #expect(dialog.title == "Direct Alert")
+        #expect(dialog.message == "Created without registry")
+        #expect(dialog.actions.count == 1)
+        
+        guard case .alert = dialog.style else {
+            Issue.record("Expected alert style")
+            return
+        }
+    }
+    
+    @Test("DialogStatus can be created directly from a Toast using the closure-based init")
+    func dialogStatusDirectInitWithToast() {
+        let status = DialogStatus {
+            Toast(config: .init(theme: .vibrant, position: .bottom)) {
+                DialogMessage("Direct Toast")
+                DialogIcon { Image(systemName: "checkmark") }
+            }
+        }
+        
+        guard case .presented(let dialog) = status.status else {
+            Issue.record("Expected presented dialog")
+            return
+        }
+        
+        #expect(dialog.message == "Direct Toast")
+        
+        guard case .toast(let config) = dialog.style else {
+            Issue.record("Expected toast style")
+            return
+        }
+        
+        #expect(config.theme == .vibrant)
+        #expect(config.position == .bottom)
+    }
+    
+    @Test("DialogStatus can be created directly from a ConfirmationDialog using the closure-based init")
+    func dialogStatusDirectInitWithConfirmationDialog() {
+        let status = DialogStatus {
+            ConfirmationDialog {
+                DialogTitle("Direct Confirmation")
+                DialogMessage("Are you sure?")
+                DialogButton(title: "Yes", role: .destructive, action: {})
+                DialogButton(title: "No", role: .cancel, action: {})
+            }
+        }
+        
+        guard case .presented(let dialog) = status.status else {
+            Issue.record("Expected presented dialog")
+            return
+        }
+        
+        #expect(dialog.title == "Direct Confirmation")
+        #expect(dialog.message == "Are you sure?")
+        #expect(dialog.actions.count == 2)
+        
+        guard case .confirmationDialog = dialog.style else {
+            Issue.record("Expected confirmationDialog style")
+            return
+        }
+    }
+    
+    @Test("UpdateDialogStatus can be initialized with a pre-built DialogProtocol instance")
+    func updateDialogStatusWithDialogProtocol() {
+        let alert = AlertDialog {
+            DialogTitle("Action Alert")
+            DialogMessage("From UpdateDialogStatus")
+            DialogButton(title: "Dismiss", action: {})
+        }
+        
+        let action = Actions.UpdateDialogStatus(dialog: alert, id: "testAction")
+        
+        guard case .presented(let dialog) = action.status.status else {
+            Issue.record("Expected presented dialog")
+            return
+        }
+        
+        #expect(dialog.title == "Action Alert")
+        #expect(dialog.message == "From UpdateDialogStatus")
+        #expect(dialog.actions.count == 1)
+        #expect(action.id == AnyHashable("testAction"))
     }
 }

--- a/UDF/Store/Action/Actions.swift
+++ b/UDF/Store/Action/Actions.swift
@@ -169,6 +169,29 @@ public enum Actions {
             self.id = AnyHashable(id)
         }
         
+        /// Initializes a new `UpdateDialogStatus` action using a type-safe DialogProtocol instance.
+        ///
+        /// Use this initializer when you have a pre-built dialog conforming to `DialogProtocol`
+        /// (e.g., `AlertDialog`, `Toast`, `ConfirmationDialog`).
+        ///
+        /// - Parameters:
+        ///   - dialog: A `DialogProtocol` conforming value.
+        ///   - id: The unique identifier for the dialog.
+        ///
+        /// ## Example:
+        /// ```swift
+        /// let alert = AlertDialog {
+        ///     DialogTitle("Error")
+        ///     DialogMessage("Something went wrong.")
+        ///     DialogButton(title: "OK") {}
+        /// }
+        /// store.dispatch(Actions.UpdateDialogStatus(dialog: alert, id: "errorDialog"))
+        /// ```
+        public init(dialog: any DialogProtocol, id: some Hashable) {
+            self.status = .init(dialog: dialog as any DialogTypeProtocol)
+            self.id = AnyHashable(id)
+        }
+        
         // MARK: - Convenience Initializers
         
         /// Initializes a new `UpdateDialogStatus` action with a success message.

--- a/UDF/View/Dialog/Core/DialogStatus.swift
+++ b/UDF/View/Dialog/Core/DialogStatus.swift
@@ -293,6 +293,30 @@ public struct DialogStatus: Equatable, Identifiable, Sendable {
         self.status = .presented(dialog)
     }
     
+    /// Initializes a dialog state using a type-safe DialogProtocol instance.
+    ///
+    /// The `@MainActor` builder closure is evaluated eagerly and the resulting
+    /// dialog is captured for presentation. This mirrors the registration
+    /// pattern used in `Dialog.register(id:dialog:)`.
+    ///
+    /// - Parameter dialog: A closure that returns a `DialogProtocol` conforming value
+    ///   (e.g., `AlertDialog`, `Toast`, `ConfirmationDialog`).
+    ///
+    /// ## Example:
+    /// ```swift
+    /// let status = DialogStatus {
+    ///     AlertDialog {
+    ///         DialogTitle("Cancel Download")
+    ///         DialogButton(title: "No", role: .cancel)
+    ///         DialogButton(title: "Cancel", role: .destructive) { /* action */ }
+    ///     }
+    /// }
+    /// ```
+    @MainActor
+    public init(dialog: @MainActor () -> any DialogProtocol) {
+        self = .init(dialog: dialog() as any DialogTypeProtocol)
+    }
+    
     /// Initializes a dismissed dialog status.
     ///
     /// Creates a dialog state that represents no active dialog.


### PR DESCRIPTION
### Description
This merge request adds a direct, type-safe path for creating dialog state and dialog update actions from DSL dialog instances, without going through the dialog registry.

The main issue addressed is that dialog presentation APIs were still biased toward registry-based registration or lower-level dialog conversion, even when the caller already had a concrete `DialogProtocol` value such as `AlertDialog`, `Toast`, or `ConfirmationDialog`. That added unnecessary indirection in tests and in action dispatch code.

The chosen approach introduces explicit initializers that accept `DialogProtocol`/builder closures and convert them internally to the existing `DialogTypeProtocol` representation. An alternative would have been to keep using registry registration everywhere, but that would preserve extra ceremony for simple one-off dialogs and make direct construction less ergonomic.

### Changes Made
- Added a new `DialogStatus` initializer that accepts a `@MainActor` closure returning `any DialogProtocol`, allowing direct creation of presented dialog state from DSL dialogs:
  ```swift
  let status = DialogStatus {
      AlertDialog {
          DialogTitle("Direct Alert")
      }
  }
  ```

- Added a new `Actions.UpdateDialogStatus` initializer that accepts a pre-built `any DialogProtocol` plus an action id:
  ```swift
  let alert = AlertDialog { ... }
  let action = Actions.UpdateDialogStatus(dialog: alert, id: "testAction")
  ```

- Covered the new direct-construction flow with tests for:
  - `AlertDialog`
  - `Toast`
  - `ConfirmationDialog`
  - `UpdateDialogStatus(dialog:id:)`

- Updated tests to use `Dialog.register(id:)` instead of `DialogRegistry.register(id:)`, reflecting the newer public registration API.

### ClickUp task
https://app.clickup.com/t/869dgw5wj