### PR TITLE
Fix compilation search paths error for 'Testing' in consumer app targets

### DIFF
--- a/UDF/Store/TestStore/TestStore.swift
+++ b/UDF/Store/TestStore/TestStore.swift
@@ -7,7 +7,6 @@
 
 import Combine
 import SwiftUI
-import Testing
 
 @globalActor public actor TestStoreActor {
     public static let shared = TestStoreActor()


### PR DESCRIPTION
## Description
This PR resolves a compilation failure encountered when importing `SwiftUI-UDF` in non-test consumer targets (like standard iOS applications).

### Problem
In recent versions, the `import Testing` statement was added to `UDF/Store/TestStore/TestStore.swift`. Because `TestStore.swift` is packaged inside the main `UDF` target (a regular library product) instead of a test target or test-support module, Xcode builds this file whenever the library is compiled. 

When a consumer app target compiles, the compiler encounters the `import Testing` line but fails because standard app targets do not include Apple's Swift Testing framework (`Testing.framework`) in their developer search paths. This results in the following compilation error:
```text
error: Compilation search paths unable to resolve module dependency: 'Testing'
```

### Solution
The `import Testing` statement in `TestStore.swift` is entirely unused by the class implementation. This PR removes the unused import, allowing the module to compile successfully for all consumer configurations without requiring special framework search paths in non-test targets.

### Verification
- Checked out the modified library dependency inside a consumer project.
- Ran `xcodebuild` for the consumer's app target.
- Verified that the `'Testing'` dependency resolution error is gone and the target compiles successfully.
