### PR TITLE
Fix Paginator Crash

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/PaginatorTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/PaginatorTests.swift
@@ -339,4 +339,12 @@ import Testing
         #expect(paginator.page.pageNumber == 1)
         #expect(paginator.page == .lastPage(1))
     }
+
+    @Test func removeItemsAfterPageWhenItemsCountFewerThanPageCapacity() {
+        var paginator = Paginator(Item.self, flowId: ItemFlow.id, perPage: 10)
+        paginator.set(items: Item.fakeItems(count: 15))
+        
+        paginator.reduce(Actions.LoadPage(pageNumber: 3, id: ItemFlow.id))
+        paginator.reduce(Actions.LoadPage(pageNumber: 2, id: ItemFlow.id))
+    }
 }

--- a/UDF/Common/Pagination/Paginator.swift
+++ b/UDF/Common/Pagination/Paginator.swift
@@ -105,7 +105,10 @@ public struct Paginator<Item: Hashable & Identifiable & Sendable, FlowId: Hashab
 
         self.page = .number(page)
         let itemsToRemove = items.count - (page * perPage)
-        items.removeLast(itemsToRemove)
+        
+        if itemsToRemove > 0 {
+            items.removeLast(itemsToRemove)
+        }
     }
 
     /// Removes all items from the paginator and sets the initial page number.


### PR DESCRIPTION
### Description
This merge request fixes a pagination edge case that could crash when navigating back to a previous page after loading beyond the available item range.

The issue occurs when the paginator trims items for a requested page, but the current item count is already smaller than that page’s capacity. In that case, the computed number of items to remove becomes negative, and `removeLast(_:)` is called with an invalid value.

The change is necessary to make page transitions safe when the data set does not fully fill the requested pages. Instead of altering the pagination flow or recalculating page boundaries differently, this MR adds a guard around item removal so trimming only happens when there are actually excess items to delete.

### Changes Made
- Prevented invalid item removal in `Paginator.load(page:)`:
  ```swift
  let itemsToRemove = items.count - (page * perPage)

  if itemsToRemove > 0 {
      items.removeLast(itemsToRemove)
  }
  ```
- Added a regression test covering the scenario where:
  - `perPage = 10`
  - 15 items are loaded
  - page 3 is requested, then page 2
- The new test verifies this sequence no longer triggers the failing removal path when item count is below the requested page capacity.