### PR TITLE
Modernize Mergeable API, Add Keep Helpers, fixes and performance improvements

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/Dialog/DialogQueueTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/DialogQueueTests.swift
@@ -319,10 +319,8 @@ import UDFSwiftTesting
         #expect(queueManager.visibleToasts.count == 1)
 
         // Wait for auto-dismiss
-        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
-
-        // Toast should be dismissed
-        #expect(queueManager.visibleToasts.count == 0)
+        let dismissed = await waitForMainActorCondition { queueManager.visibleToasts.isEmpty }
+        #expect(dismissed)
     }
 
     @Test
@@ -424,10 +422,9 @@ import UDFSwiftTesting
             queueManager.enqueue(toast)
 
             // Wait for auto-dismiss
-            await sleep(for: 0.3)
+            let dismissed = await waitForMainActorCondition { queueManager.visibleToasts.isEmpty }
+            #expect(dismissed)
         }
-
-        #expect(queueManager.visibleToasts.count == 0, "Toast should be dismissed")
     }
 
     @Test
@@ -491,7 +488,10 @@ import UDFSwiftTesting
                 #expect(queueManager.queuedToasts.count == 1)
 
                 // Wait for both toasts to auto-dismiss
-                await sleep(for: 0.5)
+                let dismissed = await waitForMainActorCondition {
+                    queueManager.visibleToasts.isEmpty && queueManager.queuedToasts.isEmpty
+                }
+                #expect(dismissed)
             }
         }
 
@@ -534,7 +534,10 @@ import UDFSwiftTesting
                 #expect(queueManager.queuedToasts.count == 0)
 
                 // Wait for both toasts to auto-dismiss
-                await sleep(for: 0.2)
+                let dismissed = await waitForMainActorCondition {
+                    queueManager.visibleToasts.isEmpty
+                }
+                #expect(dismissed)
             }
         }
 

--- a/Tests/SwiftUI-UDF-Tests/Dialog/ToastDismissCallbackTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/ToastDismissCallbackTests.swift
@@ -135,7 +135,8 @@ extension DialogRegistryTests {
             #expect(queueManager.visibleToasts.count == 1)
             
             // Wait for auto-dismiss
-            await sleep(for: 0.5)
+            let dismissed = await waitForMainActorCondition { queueManager.visibleToasts.isEmpty }
+            #expect(dismissed)
             
             // Verify callback was executed
             #expect(tracker.executed)

--- a/Tests/SwiftUI-UDF-Tests/Mergeable/MergeableTests+Extensions.swift
+++ b/Tests/SwiftUI-UDF-Tests/Mergeable/MergeableTests+Extensions.swift
@@ -15,10 +15,15 @@ extension MergeableTests {
         var tags: [String]
         var description: String?
 
-        static func merging(_ filledValue: inout ModernItem, new newValue: ModernItem, old oldValue: ModernItem) {
-            filledValue.merge(oldValue, \.number, preserving: 0)
-            filledValue.merge(oldValue, \.tags)
-            filledValue.merge(oldValue, \.description)
+        static func merging(_ newValue: inout ModernItem, old oldValue: ModernItem) {
+            newValue.restore(\.number, from: oldValue, ifNewIs: 0)
+            newValue.restore(\.tags, from: oldValue, ifNewIsEmpty: true)
+            newValue.restore(\.description, from: oldValue, ifNewIs: nil)
+
+            // Custom Rule: Restore title if the new title is shorter than 3 characters
+            newValue.restore(\.title, from: oldValue) { oldValue, newValue in
+                newValue.count < 3
+            }
         }
     }
 
@@ -44,12 +49,12 @@ extension MergeableTests {
             oldValue: ModernItem(id: .init(value: 1), title: "title", text: "text", number: 20.0, tags: ["tag2"], description: "old")
         )
     ])
-    func testMergeOverloadsComparedToTernary(newValue: ModernItem, oldValue: ModernItem) {
-        // 1. Using key-path merge overloads
-        var keyPathMerged = newValue
-        keyPathMerged.merge(oldValue, \.description)
-        keyPathMerged.merge(oldValue, \.tags)
-        keyPathMerged.merge(oldValue, \.number, preserving: 0)
+    func testRestoreOverloadsComparedToTernary(newValue: ModernItem, oldValue: ModernItem) {
+        // 1. Using key-path restore overloads
+        var keyPathRestored = newValue
+        keyPathRestored.restore(\.description, from: oldValue, ifNewIs: nil)
+        keyPathRestored.restore(\.tags, from: oldValue, ifNewIsEmpty: true)
+        keyPathRestored.restore(\.number, from: oldValue, ifNewIs: 0)
 
         // 2. Using traditional ternary / nil-coalescing equivalent logic
         var ternaryMerged = newValue
@@ -57,7 +62,25 @@ extension MergeableTests {
         ternaryMerged.tags = newValue.tags.isEmpty ? oldValue.tags : newValue.tags
         ternaryMerged.number = newValue.number == 0 ? oldValue.number : newValue.number
 
-        #expect(keyPathMerged == ternaryMerged)
+        #expect(keyPathRestored == ternaryMerged)
+    }
+
+    @Test func testRestoreCustomCondition() {
+        let old = ModernItem(id: .init(value: 1), title: "Original Title", text: "Original Text", number: 5, tags: [], description: nil)
+        
+        // Custom Rule 1: Restore if new title is shorter than old
+        var new1 = ModernItem(id: .init(value: 1), title: "Short", text: "New Text", number: 10, tags: [], description: nil)
+        new1.restore(\.title, from: old) { oldValue, newValue in
+            newValue.count < oldValue.count
+        }
+        #expect(new1.title == "Original Title")
+
+        // Custom Rule 2: Do NOT restore if new title is longer or equal
+        var new2 = ModernItem(id: .init(value: 1), title: "Very Long New Title", text: "New Text", number: 10, tags: [], description: nil)
+        new2.restore(\.title, from: old) { oldValue, newValue in
+            newValue.count < oldValue.count
+        }
+        #expect(new2.title == "Very Long New Title")
     }
 
     @Test func modernItemMerging() {
@@ -66,12 +89,33 @@ extension MergeableTests {
 
         // Test static method directly
         var mergedStatic = new
-        ModernItem.merging(&mergedStatic, new: new, old: old)
-        #expect(mergedStatic.title == "title 2")       // Auto-merged (overwritten)
-        #expect(mergedStatic.text == "new text")       // Auto-merged (overwritten)
-        #expect(mergedStatic.number == 12.23)          // Merged using KeyPath preserving 0
-        #expect(mergedStatic.tags == ["swift", "udf"]) // Merged using KeyPath preserving empty
-        #expect(mergedStatic.description == "Hello")   // Merged using KeyPath preserving nil
+        ModernItem.merging(&mergedStatic, old: old)
+        #expect(mergedStatic.title == "title 2")
+        #expect(mergedStatic.text == "new text")
+        #expect(mergedStatic.number == 12.23)
+        #expect(mergedStatic.tags == ["swift", "udf"])
+        #expect(mergedStatic.description == "Hello")
+
+        // Test instance method (calls default forwarding implementation to static method)
+        let mergedInstance = old.merging(new)
+        #expect(mergedInstance.title == "title 2")
+        #expect(mergedInstance.text == "new text")
+        #expect(mergedInstance.number == 12.23)
+        #expect(mergedInstance.tags == ["swift", "udf"])
+        #expect(mergedInstance.description == "Hello")
+
+        #expect(mergedStatic == mergedInstance)
+
+        // Test the custom rule in modern merging:
+        // New title is "hi" (length 2 < 3) -> should restore "title 1"
+        let newShortTitle = ModernItem(id: .init(value: 1), title: "hi", text: "new text", number: 0, tags: [], description: nil)
+        var mergedShort = newShortTitle
+        ModernItem.merging(&mergedShort, old: old)
+        #expect(mergedShort.title == "title 1")
+
+        // Verifying it also works via instance method forwarding
+        let mergedShortInstance = old.merging(newShortTitle)
+        #expect(mergedShortInstance.title == "title 1")
     }
 
     @Test func legacyItemBackwardsCompatibility() {
@@ -80,7 +124,7 @@ extension MergeableTests {
 
         // Test static method (calls default forwarding implementation to legacy instance method)
         var mergedStatic = new
-        Item.merging(&mergedStatic, new: new, old: old)
+        Item.merging(&mergedStatic, old: old)
         #expect(mergedStatic.title == "title 2")
         #expect(mergedStatic.text == "new text")
         #expect(mergedStatic.number == 12.23)
@@ -98,8 +142,8 @@ extension MergeableTests {
         var id: Id
         var mergeCount: Int = 0
 
-        static func merging(_ filledValue: inout TraceableItem, new newValue: TraceableItem, old oldValue: TraceableItem) {
-            filledValue.mergeCount = newValue.mergeCount + oldValue.mergeCount + 1
+        static func merging(_ newValue: inout TraceableItem, old oldValue: TraceableItem) {
+            newValue.mergeCount = newValue.mergeCount + oldValue.mergeCount + 1
         }
     }
 
@@ -132,4 +176,31 @@ extension MergeableTests {
         // Expected single merge: newValue.mergeCount (2) + oldValue.mergeCount (5) + 1 = 8
         #expect(dict[itemId]?.mergeCount == 8)
     }
+
+    @Test(arguments: [
+        (newTitle: "a", oldTitle: "Original", expected: "Original"),
+        (newTitle: "ab", oldTitle: "Original", expected: "Original"),
+        (newTitle: "", oldTitle: "Original", expected: "Original"),
+        (newTitle: "abc", oldTitle: "Original", expected: "abc"),
+        (newTitle: "abcd", oldTitle: "Original", expected: "abcd"),
+        (newTitle: "  ", oldTitle: "Original", expected: "Original"),
+        (newTitle: "   ", oldTitle: "Original", expected: "   "),
+        (newTitle: "ab", oldTitle: "xy", expected: "xy")
+    ])
+    func testModernItemCustomTitleRestoreRule(newTitle: String, oldTitle: String, expected: String) {
+        let old = ModernItem(id: .init(value: 1), title: oldTitle, text: "original text", number: 4.5, tags: ["t1"], description: "desc")
+        let new = ModernItem(id: .init(value: 1), title: newTitle, text: "new text", number: 0, tags: [], description: nil)
+        
+        // Test static merging function directly
+        var merged = new
+        ModernItem.merging(&merged, old: old)
+        
+        #expect(merged.title == expected)
+        // Ensure other fields were still merged correctly according to their restore rules:
+        #expect(merged.text == "new text")
+        #expect(merged.number == 4.5)
+        #expect(merged.tags == ["t1"])
+        #expect(merged.description == "desc")
+    }
 }
+

--- a/Tests/SwiftUI-UDF-Tests/Mergeable/MergeableTests+Extensions.swift
+++ b/Tests/SwiftUI-UDF-Tests/Mergeable/MergeableTests+Extensions.swift
@@ -15,15 +15,14 @@ extension MergeableTests {
         var tags: [String]
         var description: String?
 
-        static func merging(_ newValue: inout ModernItem, old oldValue: ModernItem) {
-            newValue.keep(\.number, from: oldValue, ifNewIs: 0)
-            newValue.keep(\.tags, from: oldValue, ifNewIsEmpty: true)
-            newValue.keep(\.description, from: oldValue, ifNewIs: nil)
+        static func merging(new newValue: ModernItem, old oldValue: ModernItem) -> ModernItem {
+            newValue
+                .keeping(\.number, from: oldValue, where: newValue.number == 0)
+                .keeping(\.tags, from: oldValue, where: newValue.tags.isEmpty)
+                .keeping(\.description, from: oldValue, where: newValue.description == nil)
 
-            // Custom Rule: Keep title if the new title is shorter than 3 characters
-            newValue.keep(\.title, from: oldValue) { oldValue, newValue in
-                newValue.count < 3
-            }
+                // Custom Rule: Keep title if the new title is shorter than 3 characters
+                .keeping(\.title, from: oldValue, where: newValue.title.count < 3)
         }
     }
 
@@ -50,11 +49,11 @@ extension MergeableTests {
         )
     ])
     func testKeepOverloadsComparedToTernary(newValue: ModernItem, oldValue: ModernItem) {
-        // 1. Using key-path keep overloads
-        var keyPathKept = newValue
-        keyPathKept.keep(\.description, from: oldValue, ifNewIs: nil)
-        keyPathKept.keep(\.tags, from: oldValue, ifNewIsEmpty: true)
-        keyPathKept.keep(\.number, from: oldValue, ifNewIs: 0)
+        // 1. Using key-path keeping overload
+        let keyPathKept = newValue
+            .keeping(\.description, from: oldValue, where: newValue.description == nil)
+            .keeping(\.tags, from: oldValue, where: newValue.tags.isEmpty)
+            .keeping(\.number, from: oldValue, where: newValue.number == 0)
 
         // 2. Using traditional ternary / nil-coalescing equivalent logic
         var ternaryMerged = newValue
@@ -69,17 +68,13 @@ extension MergeableTests {
         let old = ModernItem(id: .init(value: 1), title: "Original Title", text: "Original Text", number: 5, tags: [], description: nil)
         
         // Custom Rule 1: Keep if new title is shorter than old
-        var new1 = ModernItem(id: .init(value: 1), title: "Short", text: "New Text", number: 10, tags: [], description: nil)
-        new1.keep(\.title, from: old) { oldValue, newValue in
-            newValue.count < oldValue.count
-        }
+        let temp1 = ModernItem(id: .init(value: 1), title: "Short", text: "New Text", number: 10, tags: [], description: nil)
+        let new1 = temp1.keeping(\.title, from: old, where: temp1.title.count < old.title.count)
         #expect(new1.title == "Original Title")
 
         // Custom Rule 2: Do NOT keep if new title is longer or equal
-        var new2 = ModernItem(id: .init(value: 1), title: "Very Long New Title", text: "New Text", number: 10, tags: [], description: nil)
-        new2.keep(\.title, from: old) { oldValue, newValue in
-            newValue.count < oldValue.count
-        }
+        let temp2 = ModernItem(id: .init(value: 1), title: "Very Long New Title", text: "New Text", number: 10, tags: [], description: nil)
+        let new2 = temp2.keeping(\.title, from: old, where: temp2.title.count < old.title.count)
         #expect(new2.title == "Very Long New Title")
     }
 
@@ -88,8 +83,7 @@ extension MergeableTests {
         let new = ModernItem(id: .init(value: 1), title: "title 2", text: "new text", number: 0, tags: [], description: nil)
 
         // Test static method directly
-        var mergedStatic = new
-        ModernItem.merging(&mergedStatic, old: old)
+        let mergedStatic = ModernItem.merging(new: new, old: old)
         #expect(mergedStatic.title == "title 2")
         #expect(mergedStatic.text == "new text")
         #expect(mergedStatic.number == 12.23)
@@ -109,8 +103,7 @@ extension MergeableTests {
         // Test the custom rule in modern merging:
         // New title is "hi" (length 2 < 3) -> should keep "title 1"
         let newShortTitle = ModernItem(id: .init(value: 1), title: "hi", text: "new text", number: 0, tags: [], description: nil)
-        var mergedShort = newShortTitle
-        ModernItem.merging(&mergedShort, old: old)
+        let mergedShort = ModernItem.merging(new: newShortTitle, old: old)
         #expect(mergedShort.title == "title 1")
 
         // Verifying it also works via instance method forwarding
@@ -123,8 +116,7 @@ extension MergeableTests {
         let new = Item(id: .init(value: 1), title: "title 2", text: "new text", number: 0)
 
         // Test static method (calls default forwarding implementation to legacy instance method)
-        var mergedStatic = new
-        Item.merging(&mergedStatic, old: old)
+        let mergedStatic = Item.merging(new: new, old: old)
         #expect(mergedStatic.title == "title 2")
         #expect(mergedStatic.text == "new text")
         #expect(mergedStatic.number == 12.23)
@@ -142,8 +134,10 @@ extension MergeableTests {
         var id: Id
         var mergeCount: Int = 0
 
-        static func merging(_ newValue: inout TraceableItem, old oldValue: TraceableItem) {
-            newValue.mergeCount = newValue.mergeCount + oldValue.mergeCount + 1
+        static func merging(new newValue: TraceableItem, old oldValue: TraceableItem) -> TraceableItem {
+            var copy = newValue
+            copy.mergeCount = newValue.mergeCount + oldValue.mergeCount + 1
+            return copy
         }
     }
 
@@ -192,8 +186,7 @@ extension MergeableTests {
         let new = ModernItem(id: .init(value: 1), title: newTitle, text: "new text", number: 0, tags: [], description: nil)
         
         // Test static merging function directly
-        var merged = new
-        ModernItem.merging(&merged, old: old)
+        let merged = ModernItem.merging(new: new, old: old)
         
         #expect(merged.title == expected)
         // Ensure other fields were still merged correctly according to their keep rules:

--- a/Tests/SwiftUI-UDF-Tests/Mergeable/MergeableTests+Extensions.swift
+++ b/Tests/SwiftUI-UDF-Tests/Mergeable/MergeableTests+Extensions.swift
@@ -16,12 +16,12 @@ extension MergeableTests {
         var description: String?
 
         static func merging(_ newValue: inout ModernItem, old oldValue: ModernItem) {
-            newValue.restore(\.number, from: oldValue, ifNewIs: 0)
-            newValue.restore(\.tags, from: oldValue, ifNewIsEmpty: true)
-            newValue.restore(\.description, from: oldValue, ifNewIs: nil)
+            newValue.keep(\.number, from: oldValue, ifNewIs: 0)
+            newValue.keep(\.tags, from: oldValue, ifNewIsEmpty: true)
+            newValue.keep(\.description, from: oldValue, ifNewIs: nil)
 
-            // Custom Rule: Restore title if the new title is shorter than 3 characters
-            newValue.restore(\.title, from: oldValue) { oldValue, newValue in
+            // Custom Rule: Keep title if the new title is shorter than 3 characters
+            newValue.keep(\.title, from: oldValue) { oldValue, newValue in
                 newValue.count < 3
             }
         }
@@ -49,12 +49,12 @@ extension MergeableTests {
             oldValue: ModernItem(id: .init(value: 1), title: "title", text: "text", number: 20.0, tags: ["tag2"], description: "old")
         )
     ])
-    func testRestoreOverloadsComparedToTernary(newValue: ModernItem, oldValue: ModernItem) {
-        // 1. Using key-path restore overloads
-        var keyPathRestored = newValue
-        keyPathRestored.restore(\.description, from: oldValue, ifNewIs: nil)
-        keyPathRestored.restore(\.tags, from: oldValue, ifNewIsEmpty: true)
-        keyPathRestored.restore(\.number, from: oldValue, ifNewIs: 0)
+    func testKeepOverloadsComparedToTernary(newValue: ModernItem, oldValue: ModernItem) {
+        // 1. Using key-path keep overloads
+        var keyPathKept = newValue
+        keyPathKept.keep(\.description, from: oldValue, ifNewIs: nil)
+        keyPathKept.keep(\.tags, from: oldValue, ifNewIsEmpty: true)
+        keyPathKept.keep(\.number, from: oldValue, ifNewIs: 0)
 
         // 2. Using traditional ternary / nil-coalescing equivalent logic
         var ternaryMerged = newValue
@@ -62,22 +62,22 @@ extension MergeableTests {
         ternaryMerged.tags = newValue.tags.isEmpty ? oldValue.tags : newValue.tags
         ternaryMerged.number = newValue.number == 0 ? oldValue.number : newValue.number
 
-        #expect(keyPathRestored == ternaryMerged)
+        #expect(keyPathKept == ternaryMerged)
     }
 
-    @Test func testRestoreCustomCondition() {
+    @Test func testKeepCustomCondition() {
         let old = ModernItem(id: .init(value: 1), title: "Original Title", text: "Original Text", number: 5, tags: [], description: nil)
         
-        // Custom Rule 1: Restore if new title is shorter than old
+        // Custom Rule 1: Keep if new title is shorter than old
         var new1 = ModernItem(id: .init(value: 1), title: "Short", text: "New Text", number: 10, tags: [], description: nil)
-        new1.restore(\.title, from: old) { oldValue, newValue in
+        new1.keep(\.title, from: old) { oldValue, newValue in
             newValue.count < oldValue.count
         }
         #expect(new1.title == "Original Title")
 
-        // Custom Rule 2: Do NOT restore if new title is longer or equal
+        // Custom Rule 2: Do NOT keep if new title is longer or equal
         var new2 = ModernItem(id: .init(value: 1), title: "Very Long New Title", text: "New Text", number: 10, tags: [], description: nil)
-        new2.restore(\.title, from: old) { oldValue, newValue in
+        new2.keep(\.title, from: old) { oldValue, newValue in
             newValue.count < oldValue.count
         }
         #expect(new2.title == "Very Long New Title")
@@ -107,7 +107,7 @@ extension MergeableTests {
         #expect(mergedStatic == mergedInstance)
 
         // Test the custom rule in modern merging:
-        // New title is "hi" (length 2 < 3) -> should restore "title 1"
+        // New title is "hi" (length 2 < 3) -> should keep "title 1"
         let newShortTitle = ModernItem(id: .init(value: 1), title: "hi", text: "new text", number: 0, tags: [], description: nil)
         var mergedShort = newShortTitle
         ModernItem.merging(&mergedShort, old: old)
@@ -187,7 +187,7 @@ extension MergeableTests {
         (newTitle: "   ", oldTitle: "Original", expected: "   "),
         (newTitle: "ab", oldTitle: "xy", expected: "xy")
     ])
-    func testModernItemCustomTitleRestoreRule(newTitle: String, oldTitle: String, expected: String) {
+    func testModernItemCustomTitleKeepRule(newTitle: String, oldTitle: String, expected: String) {
         let old = ModernItem(id: .init(value: 1), title: oldTitle, text: "original text", number: 4.5, tags: ["t1"], description: "desc")
         let new = ModernItem(id: .init(value: 1), title: newTitle, text: "new text", number: 0, tags: [], description: nil)
         
@@ -196,7 +196,7 @@ extension MergeableTests {
         ModernItem.merging(&merged, old: old)
         
         #expect(merged.title == expected)
-        // Ensure other fields were still merged correctly according to their restore rules:
+        // Ensure other fields were still merged correctly according to their keep rules:
         #expect(merged.text == "new text")
         #expect(merged.number == 4.5)
         #expect(merged.tags == ["t1"])

--- a/Tests/SwiftUI-UDF-Tests/Mergeable/MergeableTests+Extensions.swift
+++ b/Tests/SwiftUI-UDF-Tests/Mergeable/MergeableTests+Extensions.swift
@@ -1,0 +1,135 @@
+@testable import UDF
+import Testing
+import OrderedCollections
+
+extension MergeableTests {
+    struct ModernItem: Mergeable, Equatable, Sendable {
+        struct Id: Hashable, Sendable {
+            var value: Int
+        }
+
+        var id: Id
+        var title: String
+        var text: String
+        var number: Double
+        var tags: [String]
+        var description: String?
+
+        static func merging(_ filledValue: inout ModernItem, new newValue: ModernItem, old oldValue: ModernItem) {
+            filledValue.merge(oldValue, \.number, preserving: 0)
+            filledValue.merge(oldValue, \.tags)
+            filledValue.merge(oldValue, \.description)
+        }
+    }
+
+    @Test(arguments: [
+        (
+            newValue: ModernItem(id: .init(value: 1), title: "title", text: "text", number: 10.0, tags: ["tag1"], description: nil),
+            oldValue: ModernItem(id: .init(value: 1), title: "title", text: "text", number: 0.0, tags: [], description: "old")
+        ),
+        (
+            newValue: ModernItem(id: .init(value: 1), title: "title", text: "text", number: 0.0, tags: [], description: "new"),
+            oldValue: ModernItem(id: .init(value: 1), title: "title", text: "text", number: 20.0, tags: ["tag2"], description: "old")
+        ),
+        (
+            newValue: ModernItem(id: .init(value: 1), title: "title", text: "text", number: 30.0, tags: ["tag3"], description: "new"),
+            oldValue: ModernItem(id: .init(value: 1), title: "title", text: "text", number: 0.0, tags: [], description: nil)
+        ),
+        (
+            newValue: ModernItem(id: .init(value: 1), title: "title", text: "text", number: 0.0, tags: [], description: nil),
+            oldValue: ModernItem(id: .init(value: 1), title: "title", text: "text", number: 0.0, tags: [], description: nil)
+        ),
+        (
+            newValue: ModernItem(id: .init(value: 1), title: "title", text: "text", number: 30.0, tags: ["tag3"], description: "new"),
+            oldValue: ModernItem(id: .init(value: 1), title: "title", text: "text", number: 20.0, tags: ["tag2"], description: "old")
+        )
+    ])
+    func testMergeOverloadsComparedToTernary(newValue: ModernItem, oldValue: ModernItem) {
+        // 1. Using key-path merge overloads
+        var keyPathMerged = newValue
+        keyPathMerged.merge(oldValue, \.description)
+        keyPathMerged.merge(oldValue, \.tags)
+        keyPathMerged.merge(oldValue, \.number, preserving: 0)
+
+        // 2. Using traditional ternary / nil-coalescing equivalent logic
+        var ternaryMerged = newValue
+        ternaryMerged.description = newValue.description ?? oldValue.description
+        ternaryMerged.tags = newValue.tags.isEmpty ? oldValue.tags : newValue.tags
+        ternaryMerged.number = newValue.number == 0 ? oldValue.number : newValue.number
+
+        #expect(keyPathMerged == ternaryMerged)
+    }
+
+    @Test func modernItemMerging() {
+        let old = ModernItem(id: .init(value: 1), title: "title 1", text: "text", number: 12.23, tags: ["swift", "udf"], description: "Hello")
+        let new = ModernItem(id: .init(value: 1), title: "title 2", text: "new text", number: 0, tags: [], description: nil)
+
+        // Test static method directly
+        var mergedStatic = new
+        ModernItem.merging(&mergedStatic, new: new, old: old)
+        #expect(mergedStatic.title == "title 2")       // Auto-merged (overwritten)
+        #expect(mergedStatic.text == "new text")       // Auto-merged (overwritten)
+        #expect(mergedStatic.number == 12.23)          // Merged using KeyPath preserving 0
+        #expect(mergedStatic.tags == ["swift", "udf"]) // Merged using KeyPath preserving empty
+        #expect(mergedStatic.description == "Hello")   // Merged using KeyPath preserving nil
+    }
+
+    @Test func legacyItemBackwardsCompatibility() {
+        let old = Item(id: .init(value: 1), title: "title 1", text: "text", number: 12.23)
+        let new = Item(id: .init(value: 1), title: "title 2", text: "new text", number: 0)
+
+        // Test static method (calls default forwarding implementation to legacy instance method)
+        var mergedStatic = new
+        Item.merging(&mergedStatic, new: new, old: old)
+        #expect(mergedStatic.title == "title 2")
+        #expect(mergedStatic.text == "new text")
+        #expect(mergedStatic.number == 12.23)
+
+        // Verify it matches direct instance merging
+        let mergedInstance = old.merging(new)
+        #expect(mergedStatic == mergedInstance)
+    }
+
+    struct TraceableItem: Mergeable, Identifiable, Equatable, Sendable {
+        struct Id: Hashable, Sendable {
+            var value: Int
+        }
+
+        var id: Id
+        var mergeCount: Int = 0
+
+        static func merging(_ filledValue: inout TraceableItem, new newValue: TraceableItem, old oldValue: TraceableItem) {
+            filledValue.mergeCount = newValue.mergeCount + oldValue.mergeCount + 1
+        }
+    }
+
+    @Test func testDictionaryInsertDoubleMerging() {
+        var dict: [TraceableItem.Id: TraceableItem] = [:]
+        let itemId = TraceableItem.Id(value: 1)
+        
+        // Initial insert when empty
+        dict.insert(item: TraceableItem(id: itemId, mergeCount: 5))
+        #expect(dict[itemId]?.mergeCount == 5)
+        
+        // Insert again to trigger merge
+        dict.insert(item: TraceableItem(id: itemId, mergeCount: 2))
+        
+        // Expected single merge: newValue.mergeCount (2) + oldValue.mergeCount (5) + 1 = 8
+        #expect(dict[itemId]?.mergeCount == 8)
+    }
+
+    @Test func testOrderedDictionaryInsertDoubleMerging() {
+        var dict: OrderedDictionary<TraceableItem.Id, TraceableItem> = [:]
+        let itemId = TraceableItem.Id(value: 1)
+        
+        // Initial insert when empty
+        dict.insert(item: TraceableItem(id: itemId, mergeCount: 5))
+        #expect(dict[itemId]?.mergeCount == 5)
+        
+        // Insert again to trigger merge
+        dict.insert(item: TraceableItem(id: itemId, mergeCount: 2))
+        
+        // Expected single merge: newValue.mergeCount (2) + oldValue.mergeCount (5) + 1 = 8
+        #expect(dict[itemId]?.mergeCount == 8)
+    }
+}

--- a/Tests/SwiftUI-UDF-Tests/Mergeable/MergeableTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Mergeable/MergeableTests.swift
@@ -27,6 +27,25 @@ struct MergeableTests {
         }
     }
 
+    struct ModernItem: Mergeable, Equatable {
+        struct Id: Hashable {
+            var value: Int
+        }
+
+        var id: Id
+        var title: String
+        var text: String
+        var number: Double
+        var tags: [String]
+        var description: String?
+
+        static func merging(_ filledValue: inout ModernItem, new newValue: ModernItem, old oldValue: ModernItem) {
+            filledValue.merge(oldValue, \.number, preserving: 0)
+            filledValue.merge(oldValue, \.tags)
+            filledValue.merge(oldValue, \.description)
+        }
+    }
+
     @Test func itemMerging() {
         var item = Item(id: .init(value: 1), title: "title 1", text: "text", number: 12.23)
         let item2 = Item(id: .init(value: 1), title: "title 2", text: "new text", number: 0)
@@ -35,5 +54,45 @@ struct MergeableTests {
         #expect(item.title == "title 2")
         #expect(item.text == "new text")
         #expect(item.number > 0)
+    }
+
+    @Test func modernItemMerging() {
+        let old = ModernItem(id: .init(value: 1), title: "title 1", text: "text", number: 12.23, tags: ["swift", "udf"], description: "Hello")
+        let new = ModernItem(id: .init(value: 1), title: "title 2", text: "new text", number: 0, tags: [], description: nil)
+
+        // Test static method directly
+        var mergedStatic = new
+        ModernItem.merging(&mergedStatic, new: new, old: old)
+        #expect(mergedStatic.title == "title 2")       // Auto-merged (overwritten)
+        #expect(mergedStatic.text == "new text")       // Auto-merged (overwritten)
+        #expect(mergedStatic.number == 12.23)          // Merged using KeyPath preserving 0
+        #expect(mergedStatic.tags == ["swift", "udf"]) // Merged using KeyPath preserving empty
+        #expect(mergedStatic.description == "Hello")   // Merged using KeyPath preserving nil
+
+        // Test instance method (calls default forwarding implementation to static method)
+        let mergedInstance = old.merging(new)
+        #expect(mergedInstance.title == "title 2")
+        #expect(mergedInstance.text == "new text")
+        #expect(mergedInstance.number == 12.23)
+        #expect(mergedInstance.tags == ["swift", "udf"])
+        #expect(mergedInstance.description == "Hello")
+
+        #expect(mergedStatic == mergedInstance)
+    }
+
+    @Test func legacyItemBackwardsCompatibility() {
+        let old = Item(id: .init(value: 1), title: "title 1", text: "text", number: 12.23)
+        let new = Item(id: .init(value: 1), title: "title 2", text: "new text", number: 0)
+
+        // Test static method (calls default forwarding implementation to legacy instance method)
+        var mergedStatic = new
+        Item.merging(&mergedStatic, new: new, old: old)
+        #expect(mergedStatic.title == "title 2")
+        #expect(mergedStatic.text == "new text")
+        #expect(mergedStatic.number == 12.23)
+
+        // Verify it matches direct instance merging
+        let mergedInstance = old.merging(new)
+        #expect(mergedStatic == mergedInstance)
     }
 }

--- a/Tests/SwiftUI-UDF-Tests/Mergeable/MergeableTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Mergeable/MergeableTests.swift
@@ -27,25 +27,6 @@ struct MergeableTests {
         }
     }
 
-    struct ModernItem: Mergeable, Equatable {
-        struct Id: Hashable {
-            var value: Int
-        }
-
-        var id: Id
-        var title: String
-        var text: String
-        var number: Double
-        var tags: [String]
-        var description: String?
-
-        static func merging(_ filledValue: inout ModernItem, new newValue: ModernItem, old oldValue: ModernItem) {
-            filledValue.merge(oldValue, \.number, preserving: 0)
-            filledValue.merge(oldValue, \.tags)
-            filledValue.merge(oldValue, \.description)
-        }
-    }
-
     @Test func itemMerging() {
         var item = Item(id: .init(value: 1), title: "title 1", text: "text", number: 12.23)
         let item2 = Item(id: .init(value: 1), title: "title 2", text: "new text", number: 0)
@@ -54,45 +35,5 @@ struct MergeableTests {
         #expect(item.title == "title 2")
         #expect(item.text == "new text")
         #expect(item.number > 0)
-    }
-
-    @Test func modernItemMerging() {
-        let old = ModernItem(id: .init(value: 1), title: "title 1", text: "text", number: 12.23, tags: ["swift", "udf"], description: "Hello")
-        let new = ModernItem(id: .init(value: 1), title: "title 2", text: "new text", number: 0, tags: [], description: nil)
-
-        // Test static method directly
-        var mergedStatic = new
-        ModernItem.merging(&mergedStatic, new: new, old: old)
-        #expect(mergedStatic.title == "title 2")       // Auto-merged (overwritten)
-        #expect(mergedStatic.text == "new text")       // Auto-merged (overwritten)
-        #expect(mergedStatic.number == 12.23)          // Merged using KeyPath preserving 0
-        #expect(mergedStatic.tags == ["swift", "udf"]) // Merged using KeyPath preserving empty
-        #expect(mergedStatic.description == "Hello")   // Merged using KeyPath preserving nil
-
-        // Test instance method (calls default forwarding implementation to static method)
-        let mergedInstance = old.merging(new)
-        #expect(mergedInstance.title == "title 2")
-        #expect(mergedInstance.text == "new text")
-        #expect(mergedInstance.number == 12.23)
-        #expect(mergedInstance.tags == ["swift", "udf"])
-        #expect(mergedInstance.description == "Hello")
-
-        #expect(mergedStatic == mergedInstance)
-    }
-
-    @Test func legacyItemBackwardsCompatibility() {
-        let old = Item(id: .init(value: 1), title: "title 1", text: "text", number: 12.23)
-        let new = Item(id: .init(value: 1), title: "title 2", text: "new text", number: 0)
-
-        // Test static method (calls default forwarding implementation to legacy instance method)
-        var mergedStatic = new
-        Item.merging(&mergedStatic, new: new, old: old)
-        #expect(mergedStatic.title == "title 2")
-        #expect(mergedStatic.text == "new text")
-        #expect(mergedStatic.number == 12.23)
-
-        // Verify it matches direct instance merging
-        let mergedInstance = old.merging(new)
-        #expect(mergedStatic == mergedInstance)
     }
 }

--- a/UDF/Common/Merging/Mergeable+Dictionary.swift
+++ b/UDF/Common/Merging/Mergeable+Dictionary.swift
@@ -25,9 +25,9 @@ public extension Dictionary where Value: Mergeable {
             if let old = self[key] {
                 var filled = newValue
                 Value.merging(&filled, new: newValue, old: old)
-                self[key] = filled
+                self.updateValue(filled, forKey: key)
             } else {
-                self[key] = newValue
+                self.updateValue(newValue, forKey: key)
             }
         }
     }
@@ -65,9 +65,9 @@ public extension Dictionary where Value: MI, Key == Value.ID {
             if let old = self[item.id] {
                 var filled = item
                 Value.merging(&filled, new: item, old: old)
-                self[item.id] = filled
+                self.updateValue(filled, forKey: item.id)
             } else {
-                self[item.id] = item
+                self.updateValue(item, forKey: item.id)
             }
         }
     }
@@ -80,9 +80,9 @@ public extension Dictionary where Value: MI, Key == Value.ID {
         if let old = self[item.id] {
             var filled = item
             Value.merging(&filled, new: item, old: old)
-            self[item.id] = filled
+            self.updateValue(filled, forKey: item.id)
         } else {
-            self[item.id] = item
+            self.updateValue(item, forKey: item.id)
         }
     }
 }

--- a/UDF/Common/Merging/Mergeable+Dictionary.swift
+++ b/UDF/Common/Merging/Mergeable+Dictionary.swift
@@ -24,7 +24,7 @@ public extension Dictionary where Value: Mergeable {
         set {
             var filled = newValue
             if let old = self[key] {
-                Value.merging(&filled, old: old)
+                filled = Value.merging(new: filled, old: old)
             }
             self.updateValue(filled, forKey: key)
         }
@@ -62,7 +62,7 @@ public extension Dictionary where Value: MI, Key == Value.ID {
         for item in items {
             var filled = item
             if let old = self[item.id] {
-                Value.merging(&filled, old: old)
+                filled = Value.merging(new: filled, old: old)
             }
             self.updateValue(filled, forKey: item.id)
         }
@@ -75,7 +75,7 @@ public extension Dictionary where Value: MI, Key == Value.ID {
     mutating func insert(item: Value) {
         var filled = item
         if let old = self[item.id] {
-            Value.merging(&filled, old: old)
+            filled = Value.merging(new: filled, old: old)
         }
         self.updateValue(filled, forKey: item.id)
     }

--- a/UDF/Common/Merging/Mergeable+Dictionary.swift
+++ b/UDF/Common/Merging/Mergeable+Dictionary.swift
@@ -22,13 +22,11 @@ public extension Dictionary where Value: Mergeable {
             preconditionFailure("You have to use optional subscript")
         }
         set {
+            var filled = newValue
             if let old = self[key] {
-                var filled = newValue
                 Value.merging(&filled, old: old)
-                self.updateValue(filled, forKey: key)
-            } else {
-                self.updateValue(newValue, forKey: key)
             }
+            self.updateValue(filled, forKey: key)
         }
     }
 }
@@ -62,13 +60,11 @@ public extension Dictionary where Value: MI, Key == Value.ID {
     ///                    If an item with the same ID already exists, it will be merged with the new item.
     mutating func insert(items: [Value]) {
         for item in items {
+            var filled = item
             if let old = self[item.id] {
-                var filled = item
                 Value.merging(&filled, old: old)
-                self.updateValue(filled, forKey: item.id)
-            } else {
-                self.updateValue(item, forKey: item.id)
             }
+            self.updateValue(filled, forKey: item.id)
         }
     }
 
@@ -77,12 +73,10 @@ public extension Dictionary where Value: MI, Key == Value.ID {
     /// - Parameter item: The item to be inserted into the dictionary.
     ///                   If an item with the same ID already exists, it will be merged with the new item.
     mutating func insert(item: Value) {
+        var filled = item
         if let old = self[item.id] {
-            var filled = item
             Value.merging(&filled, old: old)
-            self.updateValue(filled, forKey: item.id)
-        } else {
-            self.updateValue(item, forKey: item.id)
         }
+        self.updateValue(filled, forKey: item.id)
     }
 }

--- a/UDF/Common/Merging/Mergeable+Dictionary.swift
+++ b/UDF/Common/Merging/Mergeable+Dictionary.swift
@@ -22,7 +22,13 @@ public extension Dictionary where Value: Mergeable {
             preconditionFailure("You have to use optional subscript")
         }
         set {
-            self[key] = self[key]?.merging(newValue) ?? newValue
+            if let old = self[key] {
+                var filled = newValue
+                Value.merging(&filled, new: newValue, old: old)
+                self[key] = filled
+            } else {
+                self[key] = newValue
+            }
         }
     }
 }
@@ -56,7 +62,13 @@ public extension Dictionary where Value: MI, Key == Value.ID {
     ///                    If an item with the same ID already exists, it will be merged with the new item.
     mutating func insert(items: [Value]) {
         for item in items {
-            self[item.id] = self[item.id]?.merging(item) ?? item
+            if let old = self[item.id] {
+                var filled = item
+                Value.merging(&filled, new: item, old: old)
+                self[item.id] = filled
+            } else {
+                self[item.id] = item
+            }
         }
     }
 
@@ -65,6 +77,12 @@ public extension Dictionary where Value: MI, Key == Value.ID {
     /// - Parameter item: The item to be inserted into the dictionary.
     ///                   If an item with the same ID already exists, it will be merged with the new item.
     mutating func insert(item: Value) {
-        self[item.id] = self[item.id]?.merging(item) ?? item
+        if let old = self[item.id] {
+            var filled = item
+            Value.merging(&filled, new: item, old: old)
+            self[item.id] = filled
+        } else {
+            self[item.id] = item
+        }
     }
 }

--- a/UDF/Common/Merging/Mergeable+Dictionary.swift
+++ b/UDF/Common/Merging/Mergeable+Dictionary.swift
@@ -24,7 +24,7 @@ public extension Dictionary where Value: Mergeable {
         set {
             if let old = self[key] {
                 var filled = newValue
-                Value.merging(&filled, new: newValue, old: old)
+                Value.merging(&filled, old: old)
                 self.updateValue(filled, forKey: key)
             } else {
                 self.updateValue(newValue, forKey: key)
@@ -64,7 +64,7 @@ public extension Dictionary where Value: MI, Key == Value.ID {
         for item in items {
             if let old = self[item.id] {
                 var filled = item
-                Value.merging(&filled, new: item, old: old)
+                Value.merging(&filled, old: old)
                 self.updateValue(filled, forKey: item.id)
             } else {
                 self.updateValue(item, forKey: item.id)
@@ -79,7 +79,7 @@ public extension Dictionary where Value: MI, Key == Value.ID {
     mutating func insert(item: Value) {
         if let old = self[item.id] {
             var filled = item
-            Value.merging(&filled, new: item, old: old)
+            Value.merging(&filled, old: old)
             self.updateValue(filled, forKey: item.id)
         } else {
             self.updateValue(item, forKey: item.id)

--- a/UDF/Common/Merging/Mergeable+KeyPath.swift
+++ b/UDF/Common/Merging/Mergeable+KeyPath.swift
@@ -1,0 +1,48 @@
+//===--- Mergeable+KeyPath.swift -----------------------------------------===//
+//
+// This source file is part of the UDF open source project
+//
+// Copyright (c) 2026 You are launched
+// Licensed under Apache License v2.0
+//
+// See https://opensource.org/licenses/Apache-2.0 for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+public extension Mergeable {
+    /// Merges an optional property, preserving the old value if the new one is nil.
+    ///
+    /// - Parameters:
+    ///   - old: The original instance containing the old value.
+    ///   - keyPath: The WritableKeyPath to the optional property.
+    mutating func merge<T>(_ old: Self, _ keyPath: WritableKeyPath<Self, T?>) {
+        if self[keyPath: keyPath] == nil {
+            self[keyPath: keyPath] = old[keyPath: keyPath]
+        }
+    }
+
+    /// Merges a collection property, preserving the old value if the new one is empty.
+    ///
+    /// - Parameters:
+    ///   - old: The original instance containing the old value.
+    ///   - keyPath: The WritableKeyPath to the collection property.
+    mutating func merge<T: Collection>(_ old: Self, _ keyPath: WritableKeyPath<Self, T>) {
+        if self[keyPath: keyPath].isEmpty {
+            self[keyPath: keyPath] = old[keyPath: keyPath]
+        }
+    }
+
+    /// Merges a property, preserving the old value if the new one matches a specific "default" value.
+    ///
+    /// - Parameters:
+    ///   - old: The original instance containing the old value.
+    ///   - keyPath: The WritableKeyPath to the property.
+    ///   - defaultValue: The default value which triggers preservation of the old value.
+    mutating func merge<T: Equatable>(_ old: Self, _ keyPath: WritableKeyPath<Self, T>, preserving defaultValue: T) {
+        if self[keyPath: keyPath] == defaultValue {
+            self[keyPath: keyPath] = old[keyPath: keyPath]
+        }
+    }
+}

--- a/UDF/Common/Merging/Mergeable+KeyPath.swift
+++ b/UDF/Common/Merging/Mergeable+KeyPath.swift
@@ -12,51 +12,22 @@
 import Foundation
 
 public extension Mergeable {
-    /// Keeps a property from the old value if the new value matches a specific value.
+    /// Keeps a property from the old value if the condition evaluates to true.
     ///
     /// - Parameters:
     ///   - keyPath: The WritableKeyPath to the property.
     ///   - old: The original instance containing the old value.
-    ///   - value: The value which triggers keeping of the old value.
-    mutating func keep<T: Equatable>(
+    ///   - condition: An autoclosure condition that determines if the old value should be kept.
+    /// - Returns: A copy of the instance with the property reverted if the condition is met.
+    func keeping<T>(
         _ keyPath: WritableKeyPath<Self, T>,
         from old: Self,
-        ifNewIs value: T
-    ) {
-        if self[keyPath: keyPath] == value {
-            self[keyPath: keyPath] = old[keyPath: keyPath]
+        where condition: @autoclosure () -> Bool
+    ) -> Self {
+        var copy = self
+        if condition() {
+            copy[keyPath: keyPath] = old[keyPath: keyPath]
         }
-    }
-
-    /// Keeps a collection property from the old value if the new one is empty.
-    ///
-    /// - Parameters:
-    ///   - keyPath: The WritableKeyPath to the collection property.
-    ///   - old: The original instance containing the old value.
-    ///   - ifNewIsEmpty: If true, keeps the old value when the new collection is empty.
-    mutating func keep<T: Collection>(
-        _ keyPath: WritableKeyPath<Self, T>,
-        from old: Self,
-        ifNewIsEmpty: Bool
-    ) {
-        if ifNewIsEmpty && self[keyPath: keyPath].isEmpty {
-            self[keyPath: keyPath] = old[keyPath: keyPath]
-        }
-    }
-
-    /// Keeps a property from the old value based on a custom condition closure comparing old and new values.
-    ///
-    /// - Parameters:
-    ///   - keyPath: The WritableKeyPath to the property.
-    ///   - old: The original instance containing the old value.
-    ///   - condition: A closure taking the old property value and the new property value, returning true if the old value should be kept.
-    mutating func keep<T>(
-        _ keyPath: WritableKeyPath<Self, T>,
-        from old: Self,
-        where condition: (_ oldValue: T, _ newValue: T) -> Bool
-    ) {
-        if condition(old[keyPath: keyPath], self[keyPath: keyPath]) {
-            self[keyPath: keyPath] = old[keyPath: keyPath]
-        }
+        return copy
     }
 }

--- a/UDF/Common/Merging/Mergeable+KeyPath.swift
+++ b/UDF/Common/Merging/Mergeable+KeyPath.swift
@@ -12,36 +12,50 @@
 import Foundation
 
 public extension Mergeable {
-    /// Merges an optional property, preserving the old value if the new one is nil.
+    /// Restores a property from the old value if the new value matches a specific value.
     ///
     /// - Parameters:
-    ///   - old: The original instance containing the old value.
-    ///   - keyPath: The WritableKeyPath to the optional property.
-    mutating func merge<T>(_ old: Self, _ keyPath: WritableKeyPath<Self, T?>) {
-        if self[keyPath: keyPath] == nil {
-            self[keyPath: keyPath] = old[keyPath: keyPath]
-        }
-    }
-
-    /// Merges a collection property, preserving the old value if the new one is empty.
-    ///
-    /// - Parameters:
-    ///   - old: The original instance containing the old value.
-    ///   - keyPath: The WritableKeyPath to the collection property.
-    mutating func merge<T: Collection>(_ old: Self, _ keyPath: WritableKeyPath<Self, T>) {
-        if self[keyPath: keyPath].isEmpty {
-            self[keyPath: keyPath] = old[keyPath: keyPath]
-        }
-    }
-
-    /// Merges a property, preserving the old value if the new one matches a specific "default" value.
-    ///
-    /// - Parameters:
-    ///   - old: The original instance containing the old value.
     ///   - keyPath: The WritableKeyPath to the property.
-    ///   - defaultValue: The default value which triggers preservation of the old value.
-    mutating func merge<T: Equatable>(_ old: Self, _ keyPath: WritableKeyPath<Self, T>, preserving defaultValue: T) {
-        if self[keyPath: keyPath] == defaultValue {
+    ///   - old: The original instance containing the old value.
+    ///   - value: The value which triggers restoration of the old value.
+    mutating func restore<T: Equatable>(
+        _ keyPath: WritableKeyPath<Self, T>,
+        from old: Self,
+        ifNewIs value: T
+    ) {
+        if self[keyPath: keyPath] == value {
+            self[keyPath: keyPath] = old[keyPath: keyPath]
+        }
+    }
+
+    /// Restores a collection property from the old value if the new one is empty.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The WritableKeyPath to the collection property.
+    ///   - old: The original instance containing the old value.
+    ///   - ifNewIsEmpty: If true, restores the old value when the new collection is empty.
+    mutating func restore<T: Collection>(
+        _ keyPath: WritableKeyPath<Self, T>,
+        from old: Self,
+        ifNewIsEmpty: Bool
+    ) {
+        if ifNewIsEmpty && self[keyPath: keyPath].isEmpty {
+            self[keyPath: keyPath] = old[keyPath: keyPath]
+        }
+    }
+
+    /// Restores a property from the old value based on a custom condition closure comparing old and new values.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The WritableKeyPath to the property.
+    ///   - old: The original instance containing the old value.
+    ///   - condition: A closure taking the old property value and the new property value, returning true if the old value should be restored.
+    mutating func restore<T>(
+        _ keyPath: WritableKeyPath<Self, T>,
+        from old: Self,
+        where condition: (_ oldValue: T, _ newValue: T) -> Bool
+    ) {
+        if condition(old[keyPath: keyPath], self[keyPath: keyPath]) {
             self[keyPath: keyPath] = old[keyPath: keyPath]
         }
     }

--- a/UDF/Common/Merging/Mergeable+KeyPath.swift
+++ b/UDF/Common/Merging/Mergeable+KeyPath.swift
@@ -12,13 +12,13 @@
 import Foundation
 
 public extension Mergeable {
-    /// Restores a property from the old value if the new value matches a specific value.
+    /// Keeps a property from the old value if the new value matches a specific value.
     ///
     /// - Parameters:
     ///   - keyPath: The WritableKeyPath to the property.
     ///   - old: The original instance containing the old value.
-    ///   - value: The value which triggers restoration of the old value.
-    mutating func restore<T: Equatable>(
+    ///   - value: The value which triggers keeping of the old value.
+    mutating func keep<T: Equatable>(
         _ keyPath: WritableKeyPath<Self, T>,
         from old: Self,
         ifNewIs value: T
@@ -28,13 +28,13 @@ public extension Mergeable {
         }
     }
 
-    /// Restores a collection property from the old value if the new one is empty.
+    /// Keeps a collection property from the old value if the new one is empty.
     ///
     /// - Parameters:
     ///   - keyPath: The WritableKeyPath to the collection property.
     ///   - old: The original instance containing the old value.
-    ///   - ifNewIsEmpty: If true, restores the old value when the new collection is empty.
-    mutating func restore<T: Collection>(
+    ///   - ifNewIsEmpty: If true, keeps the old value when the new collection is empty.
+    mutating func keep<T: Collection>(
         _ keyPath: WritableKeyPath<Self, T>,
         from old: Self,
         ifNewIsEmpty: Bool
@@ -44,13 +44,13 @@ public extension Mergeable {
         }
     }
 
-    /// Restores a property from the old value based on a custom condition closure comparing old and new values.
+    /// Keeps a property from the old value based on a custom condition closure comparing old and new values.
     ///
     /// - Parameters:
     ///   - keyPath: The WritableKeyPath to the property.
     ///   - old: The original instance containing the old value.
-    ///   - condition: A closure taking the old property value and the new property value, returning true if the old value should be restored.
-    mutating func restore<T>(
+    ///   - condition: A closure taking the old property value and the new property value, returning true if the old value should be kept.
+    mutating func keep<T>(
         _ keyPath: WritableKeyPath<Self, T>,
         from old: Self,
         where condition: (_ oldValue: T, _ newValue: T) -> Bool

--- a/UDF/Common/Merging/Mergeable+OrderedDictionary.swift
+++ b/UDF/Common/Merging/Mergeable+OrderedDictionary.swift
@@ -18,13 +18,11 @@ public extension OrderedDictionary where Value: Mergeable {
             preconditionFailure("You have to use optional subscript")
         }
         set {
+            var filled = newValue
             if let old = self[key] {
-                var filled = newValue
                 Value.merging(&filled, old: old)
-                self.updateValue(filled, forKey: key)
-            } else {
-                self.updateValue(newValue, forKey: key)
             }
+            self.updateValue(filled, forKey: key)
         }
     }
 }
@@ -45,23 +43,19 @@ public typealias OMI = Identifiable & Mergeable
 public extension OrderedDictionary where Value: MI, Key == Value.ID {
     mutating func insert(items: [Value]) {
         for item in items {
+            var filled = item
             if let old = self[item.id] {
-                var filled = item
                 Value.merging(&filled, old: old)
-                self.updateValue(filled, forKey: item.id)
-            } else {
-                self.updateValue(item, forKey: item.id)
             }
+            self.updateValue(filled, forKey: item.id)
         }
     }
 
     mutating func insert(item: Value) {
+        var filled = item
         if let old = self[item.id] {
-            var filled = item
             Value.merging(&filled, old: old)
-            self.updateValue(filled, forKey: item.id)
-        } else {
-            self.updateValue(item, forKey: item.id)
         }
+        self.updateValue(filled, forKey: item.id)
     }
 }

--- a/UDF/Common/Merging/Mergeable+OrderedDictionary.swift
+++ b/UDF/Common/Merging/Mergeable+OrderedDictionary.swift
@@ -20,7 +20,7 @@ public extension OrderedDictionary where Value: Mergeable {
         set {
             if let old = self[key] {
                 var filled = newValue
-                Value.merging(&filled, new: newValue, old: old)
+                Value.merging(&filled, old: old)
                 self.updateValue(filled, forKey: key)
             } else {
                 self.updateValue(newValue, forKey: key)
@@ -47,7 +47,7 @@ public extension OrderedDictionary where Value: MI, Key == Value.ID {
         for item in items {
             if let old = self[item.id] {
                 var filled = item
-                Value.merging(&filled, new: item, old: old)
+                Value.merging(&filled, old: old)
                 self.updateValue(filled, forKey: item.id)
             } else {
                 self.updateValue(item, forKey: item.id)
@@ -58,7 +58,7 @@ public extension OrderedDictionary where Value: MI, Key == Value.ID {
     mutating func insert(item: Value) {
         if let old = self[item.id] {
             var filled = item
-            Value.merging(&filled, new: item, old: old)
+            Value.merging(&filled, old: old)
             self.updateValue(filled, forKey: item.id)
         } else {
             self.updateValue(item, forKey: item.id)

--- a/UDF/Common/Merging/Mergeable+OrderedDictionary.swift
+++ b/UDF/Common/Merging/Mergeable+OrderedDictionary.swift
@@ -20,7 +20,7 @@ public extension OrderedDictionary where Value: Mergeable {
         set {
             var filled = newValue
             if let old = self[key] {
-                Value.merging(&filled, old: old)
+                filled = Value.merging(new: filled, old: old)
             }
             self.updateValue(filled, forKey: key)
         }
@@ -45,7 +45,7 @@ public extension OrderedDictionary where Value: MI, Key == Value.ID {
         for item in items {
             var filled = item
             if let old = self[item.id] {
-                Value.merging(&filled, old: old)
+                filled = Value.merging(new: filled, old: old)
             }
             self.updateValue(filled, forKey: item.id)
         }
@@ -54,7 +54,7 @@ public extension OrderedDictionary where Value: MI, Key == Value.ID {
     mutating func insert(item: Value) {
         var filled = item
         if let old = self[item.id] {
-            Value.merging(&filled, old: old)
+            filled = Value.merging(new: filled, old: old)
         }
         self.updateValue(filled, forKey: item.id)
     }

--- a/UDF/Common/Merging/Mergeable+OrderedDictionary.swift
+++ b/UDF/Common/Merging/Mergeable+OrderedDictionary.swift
@@ -48,9 +48,9 @@ public extension OrderedDictionary where Value: MI, Key == Value.ID {
             if let old = self[item.id] {
                 var filled = item
                 Value.merging(&filled, new: item, old: old)
-                self[item.id] = filled
+                self.updateValue(filled, forKey: item.id)
             } else {
-                self[item.id] = item
+                self.updateValue(item, forKey: item.id)
             }
         }
     }
@@ -59,9 +59,9 @@ public extension OrderedDictionary where Value: MI, Key == Value.ID {
         if let old = self[item.id] {
             var filled = item
             Value.merging(&filled, new: item, old: old)
-            self[item.id] = filled
+            self.updateValue(filled, forKey: item.id)
         } else {
-            self[item.id] = item
+            self.updateValue(item, forKey: item.id)
         }
     }
 }

--- a/UDF/Common/Merging/Mergeable+OrderedDictionary.swift
+++ b/UDF/Common/Merging/Mergeable+OrderedDictionary.swift
@@ -18,7 +18,13 @@ public extension OrderedDictionary where Value: Mergeable {
             preconditionFailure("You have to use optional subscript")
         }
         set {
-            self.updateValue(self[key]?.merging(newValue) ?? newValue, forKey: key)
+            if let old = self[key] {
+                var filled = newValue
+                Value.merging(&filled, new: newValue, old: old)
+                self.updateValue(filled, forKey: key)
+            } else {
+                self.updateValue(newValue, forKey: key)
+            }
         }
     }
 }
@@ -39,11 +45,23 @@ public typealias OMI = Identifiable & Mergeable
 public extension OrderedDictionary where Value: MI, Key == Value.ID {
     mutating func insert(items: [Value]) {
         for item in items {
-            self[item.id] = self[item.id]?.merging(item) ?? item
+            if let old = self[item.id] {
+                var filled = item
+                Value.merging(&filled, new: item, old: old)
+                self[item.id] = filled
+            } else {
+                self[item.id] = item
+            }
         }
     }
 
     mutating func insert(item: Value) {
-        self[item.id] = self[item.id]?.merging(item) ?? item
+        if let old = self[item.id] {
+            var filled = item
+            Value.merging(&filled, new: item, old: old)
+            self[item.id] = filled
+        } else {
+            self[item.id] = item
+        }
     }
 }

--- a/UDF/Common/Merging/Mergeable.swift
+++ b/UDF/Common/Merging/Mergeable.swift
@@ -30,3 +30,17 @@ public protocol Mergeable {
     /// - Returns: A new instance of the same type, filled with values from the provided instance and modified as needed.
     func filled(from value: Self, mutate: (_ filled: inout Self, _ old: Self) -> Void) -> Self
 }
+
+public extension Mergeable {
+    /// Fills the current instance with values from another instance, and performs a custom mutation on the filled instance.
+    ///
+    /// - Parameters:
+    ///   - value: The instance to fill from.
+    ///   - mutate: A closure that allows for additional mutation on the filled instance.
+    /// - Returns: A new instance filled with values from the provided `value`.
+    func filled(from value: Self, mutate: (_ filled: inout Self, _ old: Self) -> Void) -> Self {
+        var mutableSelf = value
+        mutate(&mutableSelf, self)
+        return mutableSelf
+    }
+}

--- a/UDF/Common/Merging/Mergeable.swift
+++ b/UDF/Common/Merging/Mergeable.swift
@@ -14,10 +14,20 @@ import Foundation
 /// A protocol that allows types to define merging and filling behavior.
 /// Types conforming to `Mergeable` can combine instances and modify themselves based on other instances.
 public protocol Mergeable {
-    /// Legacy merging method (instance-based).
+    /// Merges the current instance with a new value and returns the result.
+    ///
+    /// - Parameter newValue: The new value to merge with the current instance.
+    /// - Returns: A new instance of the same type, containing the merged values of both instances.
+    @available(*, deprecated, message: "Use the static merging(_:new:old:) method instead.")
     func merging(_ newValue: Self) -> Self
 
-    /// Modernized merging method (static-based).
+    /// Merges a new value with an old value into a pre-populated mutable instance.
+    ///
+    /// - Parameters:
+    ///   - filledValue: The mutable instance where the merged result is constructed.
+    ///                  It is pre-populated with `newValue` before this method is called.
+    ///   - newValue: The incoming new instance containing updated values.
+    ///   - oldValue: The existing old instance containing previous values.
     static func merging(_ filledValue: inout Self, new newValue: Self, old oldValue: Self)
 
     /// Fills the current instance using values from another instance, allowing for further mutation.
@@ -33,6 +43,7 @@ public protocol Mergeable {
 
 public extension Mergeable {
     /// Default implementation of the legacy instance method forwards to the static method.
+    @available(*, deprecated, message: "Use the static merging(_:new:old:) method instead.")
     func merging(_ newValue: Self) -> Self {
         var filledValue = newValue
         Self.merging(&filledValue, new: newValue, old: self)

--- a/UDF/Common/Merging/Mergeable.swift
+++ b/UDF/Common/Merging/Mergeable.swift
@@ -18,17 +18,19 @@ public protocol Mergeable {
     ///
     /// - Parameter newValue: The new value to merge with the current instance.
     /// - Returns: A new instance of the same type, containing the merged values of both instances.
-    @available(*, deprecated, message: "Use the static merging(_:new:old:) method instead.")
+    @available(*, deprecated, message: "Use the static merging(_:old:) method instead.")
     func merging(_ newValue: Self) -> Self
 
     /// Merges a new value with an old value into a pre-populated mutable instance.
+    @available(*, deprecated, message: "Use the static merging(_:old:) method instead.")
+    static func merging(_ filledValue: inout Self, new newValue: Self, old oldValue: Self)
+
+    /// Merges a new value with an old value in-place, allowing properties from the old value to be selectively restored.
     ///
     /// - Parameters:
-    ///   - filledValue: The mutable instance where the merged result is constructed.
-    ///                  It is pre-populated with `newValue` before this method is called.
-    ///   - newValue: The incoming new instance containing updated values.
+    ///   - newValue: The mutating incoming instance containing updated values.
     ///   - oldValue: The existing old instance containing previous values.
-    static func merging(_ filledValue: inout Self, new newValue: Self, old oldValue: Self)
+    static func merging(_ newValue: inout Self, old oldValue: Self)
 
     /// Fills the current instance using values from another instance, allowing for further mutation.
     ///
@@ -42,18 +44,27 @@ public protocol Mergeable {
 }
 
 public extension Mergeable {
-    /// Default implementation of the legacy instance method forwards to the static method.
-    @available(*, deprecated, message: "Use the static merging(_:new:old:) method instead.")
+    /// Default implementation of the legacy instance method forwards to the new static method.
+    @available(*, deprecated, message: "Use the static merging(_:old:) method instead.")
     func merging(_ newValue: Self) -> Self {
-        var filledValue = newValue
-        Self.merging(&filledValue, new: newValue, old: self)
-        return filledValue
+        var mutableNewValue = newValue
+        Self.merging(&mutableNewValue, old: self)
+        return mutableNewValue
     }
 
-    /// Default implementation of the modern static method forwards to the legacy instance method.
+    /// Default implementation of the deprecated static method forwards to the legacy instance method.
+    @available(*, deprecated, message: "Use the static merging(_:old:) method instead.")
     static func merging(_ filledValue: inout Self, new newValue: Self, old oldValue: Self) {
         filledValue = oldValue.merging(newValue)
     }
+
+    /// Default implementation of the new static method forwards to the legacy 3-argument static method.
+    static func merging(_ newValue: inout Self, old oldValue: Self) {
+        var mutableNew = newValue
+        Self.merging(&mutableNew, new: newValue, old: oldValue)
+        newValue = mutableNew
+    }
+
     /// Fills the current instance with values from another instance, and performs a custom mutation on the filled instance.
     ///
     /// - Parameters:

--- a/UDF/Common/Merging/Mergeable.swift
+++ b/UDF/Common/Merging/Mergeable.swift
@@ -18,19 +18,15 @@ public protocol Mergeable {
     ///
     /// - Parameter newValue: The new value to merge with the current instance.
     /// - Returns: A new instance of the same type, containing the merged values of both instances.
-    @available(*, deprecated, message: "Use the static merging(_:old:) method instead.")
+    @available(*, deprecated, message: "Use the static merging(new:old:) method instead.")
     func merging(_ newValue: Self) -> Self
 
-    /// Merges a new value with an old value into a pre-populated mutable instance.
-    @available(*, deprecated, message: "Use the static merging(_:old:) method instead.")
-    static func merging(_ filledValue: inout Self, new newValue: Self, old oldValue: Self)
-
-    /// Merges a new value with an old value in-place, allowing properties from the old value to be selectively restored.
+    /// Merges a new value with an old value and returns the merged instance.
     ///
     /// - Parameters:
-    ///   - newValue: The mutating incoming instance containing updated values.
+    ///   - newValue: The incoming instance containing updated values.
     ///   - oldValue: The existing old instance containing previous values.
-    static func merging(_ newValue: inout Self, old oldValue: Self)
+    static func merging(new newValue: Self, old oldValue: Self) -> Self
 
     /// Fills the current instance using values from another instance, allowing for further mutation.
     ///
@@ -45,24 +41,14 @@ public protocol Mergeable {
 
 public extension Mergeable {
     /// Default implementation of the legacy instance method forwards to the new static method.
-    @available(*, deprecated, message: "Use the static merging(_:old:) method instead.")
+    @available(*, deprecated, message: "Use the static merging(new:old:) method instead.")
     func merging(_ newValue: Self) -> Self {
-        var mutableNewValue = newValue
-        Self.merging(&mutableNewValue, old: self)
-        return mutableNewValue
+        Self.merging(new: newValue, old: self)
     }
 
-    /// Default implementation of the deprecated static method forwards to the legacy instance method.
-    @available(*, deprecated, message: "Use the static merging(_:old:) method instead.")
-    static func merging(_ filledValue: inout Self, new newValue: Self, old oldValue: Self) {
-        filledValue = oldValue.merging(newValue)
-    }
-
-    /// Default implementation of the new static method forwards to the legacy 3-argument static method.
-    static func merging(_ newValue: inout Self, old oldValue: Self) {
-        var mutableNew = newValue
-        Self.merging(&mutableNew, new: newValue, old: oldValue)
-        newValue = mutableNew
+    /// Default implementation of the new static method forwards to the legacy instance method.
+    static func merging(new newValue: Self, old oldValue: Self) -> Self {
+        oldValue.merging(newValue)
     }
 
     /// Fills the current instance with values from another instance, and performs a custom mutation on the filled instance.

--- a/UDF/Common/Merging/Mergeable.swift
+++ b/UDF/Common/Merging/Mergeable.swift
@@ -14,11 +14,11 @@ import Foundation
 /// A protocol that allows types to define merging and filling behavior.
 /// Types conforming to `Mergeable` can combine instances and modify themselves based on other instances.
 public protocol Mergeable {
-    /// Merges the current instance with a new value and returns the result.
-    ///
-    /// - Parameter newValue: The new value to merge with the current instance.
-    /// - Returns: A new instance of the same type, containing the merged values of both instances.
+    /// Legacy merging method (instance-based).
     func merging(_ newValue: Self) -> Self
+
+    /// Modernized merging method (static-based).
+    static func merging(_ filledValue: inout Self, new newValue: Self, old oldValue: Self)
 
     /// Fills the current instance using values from another instance, allowing for further mutation.
     ///
@@ -32,6 +32,17 @@ public protocol Mergeable {
 }
 
 public extension Mergeable {
+    /// Default implementation of the legacy instance method forwards to the static method.
+    func merging(_ newValue: Self) -> Self {
+        var filledValue = newValue
+        Self.merging(&filledValue, new: newValue, old: self)
+        return filledValue
+    }
+
+    /// Default implementation of the modern static method forwards to the legacy instance method.
+    static func merging(_ filledValue: inout Self, new newValue: Self, old oldValue: Self) {
+        filledValue = oldValue.merging(newValue)
+    }
     /// Fills the current instance with values from another instance, and performs a custom mutation on the filled instance.
     ///
     /// - Parameters:

--- a/UDF/Store/Reducer/AppReducer/RuntimeReducing.swift
+++ b/UDF/Store/Reducer/AppReducer/RuntimeReducing.swift
@@ -191,28 +191,3 @@ enum RuntimeReducing {
     }
 }
 
-public extension Mergeable {
-    /// Fills the current instance with values from another instance, and performs a custom mutation on the filled instance.
-    ///
-    /// - Parameters:
-    ///   - value: The instance to fill from.
-    ///   - mutate: A closure that allows for additional mutation on the filled instance.
-    /// - Returns: A new instance filled with values from the provided `value`.
-    func filled(from value: Self, mutate: (_ filledValue: inout Self, _ oldValue: Self) -> Void) -> Self {
-        var mutableSelf = self
-        do {
-            let info = try typeInfo(of: Self.self)
-
-            for property in info.properties {
-                let newValue = try property.get(from: value)
-                try property.set(value: newValue, on: &mutableSelf)
-            }
-
-        } catch {
-            return value
-        }
-
-        mutate(&mutableSelf, self)
-        return mutableSelf
-    }
-}


### PR DESCRIPTION
# Pull Request Description

## Summary
This PR modernizes UDF's data-merging architecture. It replaces the legacy reflection-based and in-place mutating merging with a functional, declarative pipeline, introduces a single unified property-preservation API, and resolves collection double-merging bugs.

## Key Improvements
* **Pure Functional Chaining**: Replaces mutating `inout` parameters with functional chaining (`newValue.keeping(...).keeping(...)`), completely avoiding Law of Exclusivity conflicts while preserving declarative SwiftUI-inspired syntax.
* **Unified Declarative API**: Consolidates specialized overloads (such as `ifNewIs` and `ifNewIsEmpty`) into a single, generic `keeping` method taking an intuitive `@autoclosure` condition.
* **Zero Reflection**: Avoids runtime reflection (`typeInfo` lookups) in favor of direct, compiler-optimized value mapping.
* **Double-Merging Fix**: Switched dictionary and ordered dictionary updates to `updateValue(_:forKey:)` to bypass custom subscript setters and guarantee exactly one merge per insert.
* **100% Backwards Compatible**: Standard fallback implementations ensure that all legacy instance `merging` and `filled(from:mutate:)` patterns remain fully supported.

---

## Code Comparison

```swift
// old (legacy filled-closure style)
func merging(_ newValue: Customer) -> Customer {
    self.filled(from: newValue) { filledValue, oldValue in
        filledValue.biography = newValue.biography ?? oldValue.biography
        filledValue.subscriberCount = newValue.subscriberCount == 0 ? oldValue.subscriberCount : newValue.subscriberCount
        filledValue.interests = newValue.interests.isEmpty ? oldValue.interests : newValue.interests
        filledValue.name = newValue.name.count < 4 ? oldValue.name : newValue.name
    }
}

// new (declarative chaining style)
static func merging(new newValue: Customer, old oldValue: Customer) -> Customer {
    newValue
        .keeping(\.biography, from: oldValue, where: newValue.biography == nil)
        .keeping(\.subscriberCount, from: oldValue, where: newValue.subscriberCount == 0)
        .keeping(\.interests, from: oldValue, where: newValue.interests.isEmpty)
        .keeping(\.name, from: oldValue, where: newValue.name.count < 4)
}
