### PR TITLE
Fix dialog pre-evaluation

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/Dialog/DialogTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Dialog/DialogTests.swift
@@ -8,6 +8,8 @@ private extension Actions {
     struct PresentToastDialog: Action {}
     struct PresentCustomToastWithIcon: Action {}
     struct PresentCustomViewToast: Action {}
+    struct PresentDynamicDialog: Action {}
+    struct DismissDynamicDialog: Action {}
 }
 
 extension DialogType {
@@ -68,8 +70,16 @@ extension DialogRegistryTests {
                 case toastDialog
                 case customToastWithIcon
                 case customViewToast
+                case dynamicDialog
             }
             
+            enum ViewMode: Equatable {
+                case text(String)
+                case image
+            }
+            
+            var stringProperty: String = "Initial"
+            var viewMode: ViewMode = .text("Initial")
             var dialog: DialogStatus = .dismissed
             
             nonisolated mutating func reduce(_ action: some Action) {
@@ -85,6 +95,12 @@ extension DialogRegistryTests {
                     
                 case is Actions.PresentCustomViewToast:
                     dialog = .init(id: DialogId.customViewToast)
+                    
+                case is Actions.PresentDynamicDialog:
+                    dialog = .init(id: DialogId.dynamicDialog)
+                    
+                case is Actions.DismissDynamicDialog:
+                    dialog = .dismissed
                     
                 default:
                     break
@@ -438,6 +454,176 @@ extension DialogRegistryTests {
             } else {
                 Issue.record("Expected presented dialog from registry")
             }
+        }
+        @MainActor
+        @Test func dynamicDialogCustomIconCapturesLatestState() async throws {
+            ViewRenderTracker.renderHistory.removeAll()
+            let store = EnvironmentStore(initial: AppState(), loggers: [])
+            store.dispatch(UDF.Actions.UpdateFormField(keyPath: \FormWithDialog.viewMode, value: .text("TextMode")))
+            await waitForMainActorCondition { store.state.form.viewMode == .text("TextMode") }
+            
+            Dialog.register(id: FormWithDialog.DialogId.dynamicDialog) {
+                Toast {
+                    DialogIcon { 
+                        switch store.state.form.viewMode {
+                        case .image:
+                            Image(systemName: "star")
+                        case .text(let value):
+                            TrackerTestView(value: value)
+                        }
+                    }
+                    DialogMessage("Message")
+                }
+            }
+            
+            store.dispatch(Actions.PresentDynamicDialog())
+            await waitForMainActorCondition { store.state.form.dialog.status != .dismissed }
+            
+            if case .presented(let dialogType) = store.state.form.dialog.status {
+                let iconView = dialogType.getIconView(theme: .default)
+                #expect(iconView != nil)
+                #expect(ViewRenderTracker.renderHistory.last == "TextMode")
+            } else {
+                Issue.record("Expected presented dialog")
+            }
+            
+            store.dispatch(UDF.Actions.UpdateFormField(keyPath: \FormWithDialog.viewMode, value: .image))
+            await waitForMainActorCondition { store.state.form.viewMode == .image }
+            
+            store.dispatch(Actions.PresentDynamicDialog())
+            
+            await waitForMainActorCondition { 
+                if case .presented(let dialogType) = store.state.form.dialog.status {
+                    let iconView = dialogType.getIconView(theme: .default)
+                    return String(describing: iconView!).contains("Image")
+                }
+                return false
+            }
+            
+            if case .presented(let dialogType) = store.state.form.dialog.status {
+                let iconView = dialogType.getIconView(theme: .default)
+                let description = String(describing: iconView!)
+                #expect(description.contains("Image"))
+            } else {
+                Issue.record("Expected presented dialog")
+            }
+            
+            store.dispatch(UDF.Actions.UpdateFormField(keyPath: \FormWithDialog.viewMode, value: .text("NewText")))
+            await waitForMainActorCondition { store.state.form.viewMode == .text("NewText") }
+            
+            store.dispatch(Actions.PresentDynamicDialog())
+            
+            await waitForMainActorCondition { 
+                if case .presented(let dialogType) = store.state.form.dialog.status {
+                    let iconView = dialogType.getIconView(theme: .default)
+                    return String(describing: iconView!).contains("TrackerTestView")
+                }
+                return false
+            }
+            
+            if case .presented(let dialogType) = store.state.form.dialog.status {
+                let iconView = dialogType.getIconView(theme: .default)
+                #expect(iconView != nil)
+                #expect(ViewRenderTracker.renderHistory.last == "NewText")
+            } else {
+                Issue.record("Expected presented dialog")
+            }
+        }
+        
+        @MainActor
+        @Test func dynamicDialogCustomViewCapturesLatestState() async throws {
+            ViewRenderTracker.renderHistory.removeAll()
+            let store = EnvironmentStore(initial: AppState(), loggers: [])
+            store.dispatch(UDF.Actions.UpdateFormField(keyPath: \FormWithDialog.viewMode, value: .text("TextMode")))
+            await waitForMainActorCondition { store.state.form.viewMode == .text("TextMode") }
+            
+            Dialog.register(id: FormWithDialog.DialogId.dynamicDialog) {
+                Toast {
+                    DialogMessage("Message")
+                    DialogView { 
+                        switch store.state.form.viewMode {
+                        case .image:
+                            Image(systemName: "circle")
+                        case .text(let value):
+                            TrackerTestView(value: value)
+                        }
+                    }
+                }
+            }
+            
+            store.dispatch(Actions.PresentDynamicDialog())
+            await waitForMainActorCondition { store.state.form.dialog.status != .dismissed }
+            
+            if case .presented(let dialogType) = store.state.form.dialog.status {
+                let customView = dialogType.getCustomContentView()
+                #expect(customView != nil)
+                #expect(ViewRenderTracker.renderHistory.last == "TextMode")
+            } else {
+                Issue.record("Expected presented dialog")
+            }
+            
+            store.dispatch(UDF.Actions.UpdateFormField(keyPath: \FormWithDialog.viewMode, value: .image))
+            await waitForMainActorCondition { store.state.form.viewMode == .image }
+            
+            store.dispatch(Actions.PresentDynamicDialog())
+            
+            await waitForMainActorCondition { 
+                if case .presented(let dialogType) = store.state.form.dialog.status {
+                    let customView = dialogType.getCustomContentView()
+                    return String(describing: customView!).contains("Image")
+                }
+                return false
+            }
+            
+            if case .presented(let dialogType) = store.state.form.dialog.status {
+                let customView = dialogType.getCustomContentView()
+                let description = String(describing: customView!)
+                #expect(description.contains("Image"))
+            } else {
+                Issue.record("Expected presented dialog")
+            }
+            
+            store.dispatch(UDF.Actions.UpdateFormField(keyPath: \FormWithDialog.viewMode, value: .text("NextText")))
+            await waitForMainActorCondition { store.state.form.viewMode == .text("NextText") }
+            
+            store.dispatch(Actions.PresentDynamicDialog())
+            
+            await waitForMainActorCondition { 
+                if case .presented(let dialogType) = store.state.form.dialog.status {
+                    let customView = dialogType.getCustomContentView()
+                    return String(describing: customView!).contains("TrackerTestView")
+                }
+                return false
+            }
+            
+            if case .presented(let dialogType) = store.state.form.dialog.status {
+                let customView = dialogType.getCustomContentView()
+                #expect(customView != nil)
+                #expect(ViewRenderTracker.renderHistory.last == "NextText")
+            } else {
+                Issue.record("Expected presented dialog")
+            }
+        }
+
+    }
+}
+
+extension DialogRegistryTests.DialogTests {
+    @MainActor
+    class ViewRenderTracker {
+        static var renderHistory: [String] = []
+    }
+    
+    struct TrackerTestView: View {
+        let value: String
+        
+        init(value: String) {
+            self.value = value
+            ViewRenderTracker.renderHistory.append(value)
+        }
+        
+        var body: some View {
+            Text(value)
         }
     }
 }

--- a/UDF/View/Dialog/Core/DialogRegistration.swift
+++ b/UDF/View/Dialog/Core/DialogRegistration.swift
@@ -134,9 +134,8 @@ enum _DialogRegistry {
         id: ID,
         dialog: @escaping @Sendable @MainActor () -> D
     ) {
-        let dialog = dialog()
         queue.async(flags: .barrier) {
-            registry[AnyHashable(id)] = { dialog }
+            registry[AnyHashable(id)] = { dialog() }
         }
     }
     

--- a/UDF/View/Dialog/Core/Protocols/DialogProtocol.swift
+++ b/UDF/View/Dialog/Core/Protocols/DialogProtocol.swift
@@ -64,6 +64,7 @@ extension DialogProtocol {
         lhs.title == rhs.title &&
         lhs.message == rhs.message &&
         lhs.actions.count == rhs.actions.count &&
+        zip(lhs.actions, rhs.actions).allSatisfy { $0.hashValue == $1.hashValue } &&
         lhs.style == rhs.style
     }
 
@@ -71,6 +72,9 @@ extension DialogProtocol {
         hasher.combine(title)
         hasher.combine(message)
         hasher.combine(actions.count)
+        for action in actions {
+            hasher.combine(action.hashValue)
+        }
         hasher.combine(style)
     }
 

--- a/UDF/View/Dialog/Modifiers/AlertDialogModifier.swift
+++ b/UDF/View/Dialog/Modifiers/AlertDialogModifier.swift
@@ -151,6 +151,7 @@ private struct AlertState: Equatable {
     static func == (lhs: AlertState, rhs: AlertState) -> Bool {
         lhs.title == rhs.title &&
         lhs.message == rhs.message &&
-        lhs.actions.count == rhs.actions.count
+        lhs.actions.count == rhs.actions.count &&
+        zip(lhs.actions, rhs.actions).allSatisfy { $0.hashValue == $1.hashValue }
     }
 }


### PR DESCRIPTION
### Description
This merge request fixes dialog registrations that were freezing SwiftUI content at registration time instead of rebuilding it from the latest store state when the dialog is shown again.

The issue affected dynamic dialog content, especially custom icons and custom embedded views that depend on mutable state. Previously, the dialog builder was executed once during registration, so later state updates were not reflected in the rendered dialog. The change switches registration to store the builder closure itself and invoke it on demand, ensuring dialog content is recreated with current state.

To support correct diffing of dialog updates, dialog equality/hashing was also tightened to account for action identity rather than only action count. Without this, dialogs with different button sets but the same number of actions could be treated as unchanged.

### Changes Made
- Changed dialog registration to defer dialog construction until retrieval/presentation:
  ```swift
  registry[AnyHashable(id)] = { dialog() }
  ```
  instead of precomputing a single dialog instance during `register`.

- Added regression tests covering dynamic dialog rendering from live state:
  - `dynamicDialogCustomIconCapturesLatestState`
  - `dynamicDialogCustomViewCapturesLatestState`

- Extended test dialog state with:
  - a new `dynamicDialog` identifier
  - `PresentDynamicDialog` / `DismissDynamicDialog` actions
  - a `viewMode` enum that switches between text-driven and image-driven content

- Added test helpers to verify that rebuilt views use the latest state:
  - `TrackerTestView`
  - `ViewRenderTracker`

- Updated `DialogProtocol` equality/hash logic so dialog actions are compared and hashed by content/order via each action’s `hashValue`, not just by action count.

- Applied the same action-level equality check to `AlertState`, preventing alerts with changed actions but identical counts from being considered equal.

### ClickUp task
https://app.clickup.com/t/869e5j9n2