### PR TITLE
Add support for [any Action] array expressions in ActionGroupBuilder

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/ActionGroup/ActionGroupBuilderTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/ActionGroup/ActionGroupBuilderTests.swift
@@ -189,6 +189,49 @@ import Foundation
         
         #expect(InternalAction(group).unwrapActions().count == 6)
     }
+
+    @Test func actionsArrayExpression() {
+        let analyticsActions: [any Action] = [
+            Actions.Message(message: "a1", id: "a1"),
+            Actions.Message(message: "a2", id: "a2"),
+        ]
+
+        let group = ActionGroup {
+            Actions.Message(message: "m1", id: "m1")
+            analyticsActions
+        }
+
+        #expect(group.actions.count == 3)
+    }
+
+    @Test func mixedIndividualActionsAndArrayOfActions() {
+        let firstBatch: [any Action] = [
+            Actions.Message(message: "b1", id: "b1"),
+            Actions.Message(message: "b2", id: "b2"),
+        ]
+        let secondBatch: [any Action] = [
+            Actions.Message(message: "b3", id: "b3"),
+        ]
+
+        let group = ActionGroup {
+            firstBatch
+            Actions.Message(message: "m1", id: "m1")
+            secondBatch
+        }
+
+        #expect(group.actions.count == 4)
+    }
+
+    @Test func emptyActionsArrayExpression() {
+        let emptyActions: [any Action] = []
+
+        let group = ActionGroup {
+            Actions.Message(message: "m1", id: "m1")
+            emptyActions
+        }
+
+        #expect(group.actions.count == 1)
+    }
 }
 
 // MARK: - Test Types

--- a/UDF/Store/Action/ActionGroup/ActionGroupBuilder.swift
+++ b/UDF/Store/Action/ActionGroup/ActionGroupBuilder.swift
@@ -117,6 +117,30 @@ public enum ActionGroupBuilder {
         ]
     }
 
+    /// Converts an array of actions (`[any Action]`) into an array of `InternalAction`.
+    ///
+    /// - Parameters:
+    ///   - expression: An array of `any Action` to be converted.
+    ///   - fileName: The name of the file where this method is called. Defaults to the current file.
+    ///   - functionName: The name of the function where this method is called. Defaults to the current function.
+    ///   - lineNumber: The line number where this method is called. Defaults to the current line.
+    /// - Returns: An array containing the converted `InternalAction`s.
+    public static func buildExpression(
+        _ expression: [any Action],
+        fileName: String = #file,
+        functionName: String = #function,
+        lineNumber: Int = #line
+    ) -> [any Equatable] {
+        expression.map {
+            InternalAction(
+                $0,
+                fileName: fileName,
+                functionName: functionName,
+                lineNumber: lineNumber
+            )
+        }
+    }
+
     /// Handles a `Void` expression, returning an empty array.
     ///
     /// - Parameter expression: A `Void` expression.


### PR DESCRIPTION
### Description
This merge request fixes a gap in `ActionGroupBuilder` where result-builder expressions could wrap individual `Action` values but not arrays of actions (`[any Action]`). That limitation prevented composing prebuilt action batches inside `ActionGroup` blocks.

The change is necessary to support more flexible action composition, especially when actions are prepared dynamically or grouped beforehand. The chosen approach extends the builder with a dedicated `buildExpression` overload for `[any Action]`, which keeps the existing builder API intact and avoids requiring callers to manually flatten or wrap arrays elsewhere.

### Changes Made
- Added a new `ActionGroupBuilder.buildExpression(_ expression: [any Action], ...)` overload.
  - Converts each action in the input array into an `InternalAction`
  - Preserves source-location metadata (`fileName`, `functionName`, `lineNumber`) for each wrapped action

```swift
public static func buildExpression(
    _ expression: [any Action],
    fileName: String = #file,
    functionName: String = #function,
    lineNumber: Int = #line
) -> [any Equatable] {
    expression.map {
        InternalAction(
            $0,
            fileName: fileName,
            functionName: functionName,
            lineNumber: lineNumber
        )
    }
}
```

- Added test coverage for array-based expressions inside `ActionGroup`:
  - using a single array alongside an individual action
  - mixing multiple arrays with individual actions
  - handling an empty action array without adding extra entries

- The new tests verify that arrays are flattened into the group correctly by asserting the final `actions.count` in each composition scenario.

### ClickUp task
https://app.clickup.com/t/869e5pdw8