### PR TITLE
Add CancelAll coverage for task/execute/run middleware effects

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/Actions/DelayedActionTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Actions/DelayedActionTests.swift
@@ -2,6 +2,7 @@
 @testable import UDF
 import UDFSwiftTesting
 import Testing
+import Foundation
 
 @Suite(.serialized) struct DelayedActionTests {
     private struct TestStoreLogger: ActionLogger {
@@ -142,43 +143,64 @@ import Testing
         let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
         let clock = ContinuousClock()
         let start = clock.now
-        
+        let delay: TimeInterval = 1
+        let timingTolerance = 0.1
+
         let titleText = "title"
         let updatedTitleText = "updated title"
-        store.dispatch(ActionGroup {
+        store.dispatch {
             Actions.UpdateFormField(keyPath: \DataForm.title, value: titleText)
-            Actions.UpdateFormField(keyPath: \DataForm.title, value: updatedTitleText).with(delay: 1)
-            Actions.UpdateFormField(keyPath: \DataForm.count, value: 10).with(delay: 1)
-        })
+            Actions.UpdateFormField(keyPath: \DataForm.title, value: updatedTitleText).with(delay: delay)
+            Actions.UpdateFormField(keyPath: \DataForm.count, value: 10).with(delay: delay)
+        }
 
         var success = await waitForCondition { store.state.dataForm.title == titleText }
         #expect(success, "Regular action should be reduced without waiting for delayed actions")
-        success = await waitForCondition { store.state.dataForm.title == updatedTitleText && store.state.dataForm.count == 10 }
-        #expect(success, "All delayed and regular actions should complete without hanging")
+        var elapsed = start.duration(to: clock.now)
+        #expect(
+            (Duration.seconds(0)...Duration.seconds(timingTolerance)).contains(elapsed),
+            "Regular actions should execute immediately"
+        )
+        #expect(success, "Regular action should be reduced without waiting for delayed actions")
+        success = await waitForCondition(timeout: 1 + timingTolerance) {
+            store.state.dataForm.title == updatedTitleText && store.state.dataForm.count == 10
+        }
+        #expect(success, "Delayed actions should complete within the 1 second delay tolerance")
 
-        let elapsed = start.duration(to: clock.now)
-        #expect(elapsed >= .seconds(1), "Expected delayed actions to take at least 1 second, got \(elapsed)")
-        #expect(elapsed <= .seconds(2), "Expected delayed actions to finish within 2 seconds, got \(elapsed)")
+        elapsed = start.duration(to: clock.now)
+        #expect(
+            (Duration.seconds(delay - timingTolerance)...Duration.seconds(delay + timingTolerance)).contains(elapsed),
+            "Expected elapsed time to stay within the delay tolerance window"
+        )
     }
 
     @Test func delayedActionsAndRegularDispatchWithSeparateDispatching() async throws {
         let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
         let clock = ContinuousClock()
         let start = clock.now
+        let delay: TimeInterval = 1
+        let timingTolerance = 0.1
 
         let titleText = "title"
         let updatedTitleText = "updated title"
         store.dispatch(Actions.UpdateFormField(keyPath: \DataForm.title, value: titleText))
-        store.dispatch(Actions.UpdateFormField(keyPath: \DataForm.title, value: updatedTitleText).with(delay: 1))
-        store.dispatch(Actions.UpdateFormField(keyPath: \DataForm.count, value: 10).with(delay: 1))
+        store.dispatch(Actions.UpdateFormField(keyPath: \DataForm.title, value: updatedTitleText).with(delay: delay))
+        store.dispatch(Actions.UpdateFormField(keyPath: \DataForm.count, value: 10).with(delay: delay))
 
         var success = await waitForCondition { store.state.dataForm.title == titleText }
         #expect(success, "Regular action should be reduced without waiting for delayed actions")
+        var elapsed = start.duration(to: clock.now)
+        #expect(
+            (Duration.seconds(0)...Duration.seconds(timingTolerance)).contains(elapsed),
+            "Regular actions should execute immediately"
+        )
         success = await waitForCondition { store.state.dataForm.title == updatedTitleText && store.state.dataForm.count == 10 }
         #expect(success, "All delayed and regular actions should complete without hanging")
 
-        let elapsed = start.duration(to: clock.now)
-        #expect(elapsed >= .seconds(1), "Expected delayed actions to take at least 1 second, got \(elapsed)")
-        #expect(elapsed <= .seconds(2), "Expected delayed actions to finish within 2 seconds, got \(elapsed)")
+        elapsed = start.duration(to: clock.now)
+        #expect(
+            (Duration.seconds(delay - timingTolerance)...Duration.seconds(delay + timingTolerance)).contains(elapsed),
+            "Expected elapsed time to stay within the delay tolerance window"
+        )
     }
 }

--- a/Tests/SwiftUI-UDF-Tests/Actions/DelayedActionTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Actions/DelayedActionTests.swift
@@ -137,4 +137,48 @@ import Testing
         success = await waitForCondition { store.state.dataForm.count == 5 }
         #expect(success)
     }
+
+    @Test func delayedActionsAndRegularDispatchWithActionGroup() async throws {
+        let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
+        let clock = ContinuousClock()
+        let start = clock.now
+        
+        let titleText = "title"
+        let updatedTitleText = "updated title"
+        store.dispatch(ActionGroup {
+            Actions.UpdateFormField(keyPath: \DataForm.title, value: titleText)
+            Actions.UpdateFormField(keyPath: \DataForm.title, value: updatedTitleText).with(delay: 1)
+            Actions.UpdateFormField(keyPath: \DataForm.count, value: 10).with(delay: 1)
+        })
+
+        var success = await waitForCondition { store.state.dataForm.title == titleText }
+        #expect(success, "Regular action should be reduced without waiting for delayed actions")
+        success = await waitForCondition { store.state.dataForm.title == updatedTitleText && store.state.dataForm.count == 10 }
+        #expect(success, "All delayed and regular actions should complete without hanging")
+
+        let elapsed = start.duration(to: clock.now)
+        #expect(elapsed >= .seconds(1), "Expected delayed actions to take at least 1 second, got \(elapsed)")
+        #expect(elapsed <= .seconds(2), "Expected delayed actions to finish within 2 seconds, got \(elapsed)")
+    }
+
+    @Test func delayedActionsAndRegularDispatchWithSeparateDispatching() async throws {
+        let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        let titleText = "title"
+        let updatedTitleText = "updated title"
+        store.dispatch(Actions.UpdateFormField(keyPath: \DataForm.title, value: titleText))
+        store.dispatch(Actions.UpdateFormField(keyPath: \DataForm.title, value: updatedTitleText).with(delay: 1))
+        store.dispatch(Actions.UpdateFormField(keyPath: \DataForm.count, value: 10).with(delay: 1))
+
+        var success = await waitForCondition { store.state.dataForm.title == titleText }
+        #expect(success, "Regular action should be reduced without waiting for delayed actions")
+        success = await waitForCondition { store.state.dataForm.title == updatedTitleText && store.state.dataForm.count == 10 }
+        #expect(success, "All delayed and regular actions should complete without hanging")
+
+        let elapsed = start.duration(to: clock.now)
+        #expect(elapsed >= .seconds(1), "Expected delayed actions to take at least 1 second, got \(elapsed)")
+        #expect(elapsed <= .seconds(2), "Expected delayed actions to finish within 2 seconds, got \(elapsed)")
+    }
 }

--- a/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
@@ -90,7 +90,8 @@ import Foundation
         await store.dispatch(Actions.CancelLoading())
         await store.wait()
 
-        success = await store.state.middlewareFlow == .none
+        success = await waitForCondition { await store.state.middlewareFlow == .none }
+        
         #expect(success)
     }
 
@@ -146,105 +147,39 @@ import Foundation
         
         await store.wait()
     }
-    
-    @Test func testMiddlewareCancellationAllTask() async {
+
+    @Test(arguments: CancellationAllAction.allCases)
+    func testMiddlewareCancellationAll(action: CancellationAllAction) async throws {
         let store = await TestStore(initial: AppState())
         var observableMiddlewareToCancelAll: ObservableMiddlewareToCancelAll?
-        await store.subscribe(buildMiddlewares: { store in
+        await store.subscribe(build: { store in
             let middleware = ObservableMiddlewareToCancelAll(store: store, environment: ())
             observableMiddlewareToCancelAll = middleware
-            return [middleware]
+            return [MiddlewareWrapper(instance: middleware)]
         })
 
         let tasks = 10
         for id in 0..<tasks {
-            await store.dispatch(Actions.RunTaskByID(id: id))
+            await store.dispatch(action.makeActions(id: id))
         }
 
         try? await Task.sleep(for: .milliseconds(100))
 
-        #expect(observableMiddlewareToCancelAll != nil, "The test should capture the subscribed ObservableMiddlewareToCancelAll instance")
+        let middleware = try #require(observableMiddlewareToCancelAll, "The test should capture the subscribed ObservableMiddlewareToCancelAll instance")
         #expect(
-            observableMiddlewareToCancelAll?.cancellations.count == tasks,
-            "Expected \(tasks) tracked cancellations before CancelAll, got \(observableMiddlewareToCancelAll?.cancellations.count ?? 0)"
+            middleware.cancellations.count == tasks,
+            "Expected \(tasks) tracked cancellations before CancelAll, got \(middleware.cancellations.count)"
         )
 
         await store.dispatch(Actions.CancelAll())
         await store.wait()
 
         #expect(
-            observableMiddlewareToCancelAll?.cancellations.count == 0,
-            "Expected all tracked cancellations to be removed after CancelAll, got \(observableMiddlewareToCancelAll?.cancellations.count ?? 0)"
+            middleware.cancellations.count == 0,
+            "Expected all tracked cancellations to be removed after CancelAll, got \(middleware.cancellations.count)"
         )
-
-        let taskMessagesCount = await store.state.runForm.messagesCount
-        #expect(taskMessagesCount == 0, "Message count should be unincremented after cancelling all tasks")
-    }
-
-    @Test func testMiddlewareCancellationAllExecuteEffect() async {
-        let store = await TestStore(initial: AppState())
-        var observableMiddlewareToCancelAll: ObservableMiddlewareToCancelAll?
-        await store.subscribe(buildMiddlewares: { store in
-            let middleware = ObservableMiddlewareToCancelAll(store: store, environment: ())
-            observableMiddlewareToCancelAll = middleware
-            return [middleware]
-        })
-
-        let tasks = 10
-        for id in 0..<tasks {
-            await store.dispatch(Actions.ExecuteEffectByID(id: id))
-        }
-
-        try? await Task.sleep(for: .milliseconds(100))
-
-        #expect(observableMiddlewareToCancelAll != nil, "The test should capture the subscribed ObservableMiddlewareToCancelAll instance")
-        #expect(
-            observableMiddlewareToCancelAll?.cancellations.count == tasks,
-            "Expected \(tasks) tracked cancellations before CancelAll, got \(observableMiddlewareToCancelAll?.cancellations.count ?? 0)"
-        )
-
-        await store.dispatch(Actions.CancelAll())
-        await store.wait()
-
-        #expect(
-            observableMiddlewareToCancelAll?.cancellations.count == 0,
-            "Expected all tracked cancellations to be removed after CancelAll, got \(observableMiddlewareToCancelAll?.cancellations.count ?? 0)"
-        )
-        let executeEffectMessagesCount = await store.state.runForm.messagesCount
-        #expect(executeEffectMessagesCount == 0, "Message count should be unincremented after cancelling all effects")
-    }
-
-    @Test func testMiddlewareCancellationAllRunEffect() async {
-        let store = await TestStore(initial: AppState())
-        var observableMiddlewareToCancelAll: ObservableMiddlewareToCancelAll?
-        await store.subscribe(buildMiddlewares: { store in
-            let middleware = ObservableMiddlewareToCancelAll(store: store, environment: ())
-            observableMiddlewareToCancelAll = middleware
-            return [middleware]
-        })
-
-        let tasks = 10
-        for id in 0..<tasks {
-            await store.dispatch(Actions.RunEffectByID(id: id))
-        }
-
-        try? await Task.sleep(for: .milliseconds(100))
-
-        #expect(observableMiddlewareToCancelAll != nil, "The test should capture the subscribed ObservableMiddlewareToCancelAll instance")
-        #expect(
-            observableMiddlewareToCancelAll?.cancellations.count == tasks,
-            "Expected \(tasks) tracked cancellations before CancelAll, got \(observableMiddlewareToCancelAll?.cancellations.count ?? 0)"
-        )
-
-        await store.dispatch(Actions.CancelAll())
-        await store.wait()
-
-        #expect(
-            observableMiddlewareToCancelAll?.cancellations.count == 0,
-            "Expected all tracked cancellations to be removed after CancelAll, got \(observableMiddlewareToCancelAll?.cancellations.count ?? 0)"
-        )
-        let runEffectMessagesCount = await store.state.runForm.messagesCount
-        #expect(runEffectMessagesCount == 0, "Message count should be unincremented after cancelling all run effects")
+        let messagesCount = await store.state.runForm.messagesCount
+        #expect(messagesCount == 0, "Message count should remain unchanged after cancelling all \(action.description)")
     }
 }
 
@@ -415,6 +350,44 @@ private extension MiddlewareCancellationTests {
 
             default:
                 break
+            }
+        }
+    }
+}
+
+extension MiddlewareCancellationTests {
+    enum CancellationAllAction: CaseIterable, Sendable, CustomStringConvertible {
+        case task
+        case executeEffect
+        case runEffect
+        case all
+
+        var description: String {
+            switch self {
+            case .task:
+                "tasks"
+            case .executeEffect:
+                "execute effects"
+            case .runEffect:
+                "run effects"
+            case .all:
+                "all executable task types"
+            }
+        }
+
+        @ActionGroupBuilder
+        func makeActions(id: Int) -> any Action {
+            switch self {
+            case .task:
+                Actions.RunTaskByID(id: id)
+            case .executeEffect:
+                Actions.ExecuteEffectByID(id: id)
+            case .runEffect:
+                Actions.RunEffectByID(id: id)
+            case .all:
+                Actions.RunTaskByID(id: id)
+                Actions.ExecuteEffectByID(id: id)
+                Actions.RunEffectByID(id: id)
             }
         }
     }

--- a/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
@@ -12,7 +12,14 @@ import Foundation
     }
 
     enum MiddlewareFlow: IdentifiableFlow {
-        case none, loading, cancel, message
+        case none
+        case loading
+        case loadingTask(id: Int)
+        case executeEffect(id: Int)
+        case runEffect(id: Int)
+        case cancel
+        case cancelAll
+        case message
 
         init() { self = .none }
 
@@ -28,11 +35,27 @@ import Foundation
             case let action as Actions.DidCancelEffect where action.cancellation == ObservableRunMiddlewareToCancel.Сancellation.runMessage:
                 self = .none
 
+            case let action as Actions.DidCancelEffect
+                where action.cancellation is ObservableMiddlewareToCancelAll.Сancellation:
+                self = .none
+
             case is Actions.Loading:
                 self = .loading
 
             case is Actions.CancelLoading:
                 self = .cancel
+                
+            case is Actions.CancelAll:
+                self = .cancelAll
+                
+            case let action as Actions.RunTaskByID:
+                self = .loadingTask(id: action.id)
+                
+            case let action as Actions.ExecuteEffectByID:
+                self = .executeEffect(id: action.id)
+
+            case let action as Actions.RunEffectByID:
+                self = .runEffect(id: action.id)
 
             case is Actions.Message:
                 self = .message
@@ -123,15 +146,168 @@ import Foundation
         
         await store.wait()
     }
+    
+    @Test func testMiddlewareCancellationAllTask() async {
+        let store = await TestStore(initial: AppState())
+        var observableMiddlewareToCancelAll: ObservableMiddlewareToCancelAll?
+        await store.subscribe(buildMiddlewares: { store in
+            let middleware = ObservableMiddlewareToCancelAll(store: store, environment: ())
+            observableMiddlewareToCancelAll = middleware
+            return [middleware]
+        })
+
+        let tasks = 10
+        for id in 0..<tasks {
+            await store.dispatch(Actions.RunTaskByID(id: id))
+        }
+
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(observableMiddlewareToCancelAll != nil, "The test should capture the subscribed ObservableMiddlewareToCancelAll instance")
+        #expect(
+            observableMiddlewareToCancelAll?.cancellations.count == tasks,
+            "Expected \(tasks) tracked cancellations before CancelAll, got \(observableMiddlewareToCancelAll?.cancellations.count ?? 0)"
+        )
+
+        await store.dispatch(Actions.CancelAll())
+        await store.wait()
+
+        #expect(
+            observableMiddlewareToCancelAll?.cancellations.count == 0,
+            "Expected all tracked cancellations to be removed after CancelAll, got \(observableMiddlewareToCancelAll?.cancellations.count ?? 0)"
+        )
+
+        let taskMessagesCount = await store.state.runForm.messagesCount
+        #expect(taskMessagesCount == 0, "Message count should be unincremented after cancelling all tasks")
+    }
+
+    @Test func testMiddlewareCancellationAllExecuteEffect() async {
+        let store = await TestStore(initial: AppState())
+        var observableMiddlewareToCancelAll: ObservableMiddlewareToCancelAll?
+        await store.subscribe(buildMiddlewares: { store in
+            let middleware = ObservableMiddlewareToCancelAll(store: store, environment: ())
+            observableMiddlewareToCancelAll = middleware
+            return [middleware]
+        })
+
+        let tasks = 10
+        for id in 0..<tasks {
+            await store.dispatch(Actions.ExecuteEffectByID(id: id))
+        }
+
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(observableMiddlewareToCancelAll != nil, "The test should capture the subscribed ObservableMiddlewareToCancelAll instance")
+        #expect(
+            observableMiddlewareToCancelAll?.cancellations.count == tasks,
+            "Expected \(tasks) tracked cancellations before CancelAll, got \(observableMiddlewareToCancelAll?.cancellations.count ?? 0)"
+        )
+
+        await store.dispatch(Actions.CancelAll())
+        await store.wait()
+
+        #expect(
+            observableMiddlewareToCancelAll?.cancellations.count == 0,
+            "Expected all tracked cancellations to be removed after CancelAll, got \(observableMiddlewareToCancelAll?.cancellations.count ?? 0)"
+        )
+        let executeEffectMessagesCount = await store.state.runForm.messagesCount
+        #expect(executeEffectMessagesCount == 0, "Message count should be unincremented after cancelling all effects")
+    }
+
+    @Test func testMiddlewareCancellationAllRunEffect() async {
+        let store = await TestStore(initial: AppState())
+        var observableMiddlewareToCancelAll: ObservableMiddlewareToCancelAll?
+        await store.subscribe(buildMiddlewares: { store in
+            let middleware = ObservableMiddlewareToCancelAll(store: store, environment: ())
+            observableMiddlewareToCancelAll = middleware
+            return [middleware]
+        })
+
+        let tasks = 10
+        for id in 0..<tasks {
+            await store.dispatch(Actions.RunEffectByID(id: id))
+        }
+
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(observableMiddlewareToCancelAll != nil, "The test should capture the subscribed ObservableMiddlewareToCancelAll instance")
+        #expect(
+            observableMiddlewareToCancelAll?.cancellations.count == tasks,
+            "Expected \(tasks) tracked cancellations before CancelAll, got \(observableMiddlewareToCancelAll?.cancellations.count ?? 0)"
+        )
+
+        await store.dispatch(Actions.CancelAll())
+        await store.wait()
+
+        #expect(
+            observableMiddlewareToCancelAll?.cancellations.count == 0,
+            "Expected all tracked cancellations to be removed after CancelAll, got \(observableMiddlewareToCancelAll?.cancellations.count ?? 0)"
+        )
+        let runEffectMessagesCount = await store.state.runForm.messagesCount
+        #expect(runEffectMessagesCount == 0, "Message count should be unincremented after cancelling all run effects")
+    }
 }
 
 private extension Actions {
     struct Loading: Action {}
+    struct RunTaskByID: Action {
+        let id: Int
+    }
+    struct ExecuteEffectByID: Action {
+        let id: Int
+    }
+    struct RunEffectByID: Action {
+        let id: Int
+    }
     struct CancelLoading: Action {}
+    struct CancelAll: Action {}
 }
 
 // MARK: - Middlewares
 private extension MiddlewareCancellationTests {
+    final class ObservableMiddlewareToCancelAll: Middleware<AppState>, @unchecked Sendable {
+        var environment: Void!
+        
+        enum Сancellation: Hashable {
+            case message(Int)
+        }
+
+        func scope(for state: AppState) -> Scope {
+            state.middlewareFlow
+        }
+        
+        func observe(state: AppState) {
+            switch state.middlewareFlow {
+            case let .loadingTask(id):
+                execute(
+                    flowId: MiddlewareFlow.id,
+                    cancellation: Сancellation.message(id)
+                ) { flowID in
+                    try? await Task.sleep(for: .seconds(1))
+                    return Actions.Message(message: "message \(id)", id: flowID)
+                }
+                
+            case let .executeEffect(id):
+                execute(
+                    Effect(action: Actions.Message(message: "message \(id)", id: MiddlewareFlow.id)).delay(duration: 1, queue: queue),
+                    cancellation: Сancellation.message(id)
+                )
+
+            case let .runEffect(id):
+                run(
+                    Effect(action: Actions.Message(message: "message \(id)", id: MiddlewareFlow.id)).delay(duration: 1, queue: queue),
+                    cancellation: Сancellation.message(id)
+                )
+
+            case .cancelAll:
+                cancelAll()
+
+            default:
+                break
+            }
+        }
+    }
+    
     final class ObservableMiddlewareToCancel: Middleware<AppState>, @unchecked Sendable {
         var environment: Void!
 
@@ -243,4 +419,3 @@ private extension MiddlewareCancellationTests {
         }
     }
 }
-


### PR DESCRIPTION
### Description
This merge request adds regression coverage for two concurrency-sensitive behaviors in the store and middleware layers:

1. **Mixed immediate and delayed action dispatching must not block regular actions.**  
   The new tests verify that when delayed actions are dispatched together with immediate ones—either inside an `ActionGroup` or through separate dispatch calls—the immediate action is reduced right away, while delayed actions still complete later within the expected time window. This protects against hangs or unintended serialization of dispatch processing.

2. **Middleware must support cancelling all in-flight work across different execution APIs.**  
   The cancellation test suite now covers bulk cancellation for tasks started via `execute`, delayed `Effect` execution, and `run`. These changes are necessary to validate that `cancelAll()` clears tracked cancellations and prevents any deferred message actions from reaching state after cancellation.

No alternative implementation is introduced here; the MR focuses on expanding test coverage around behavior that is easy to regress in async dispatch and middleware cancellation handling.

### Changes Made
- Added delayed-dispatch tests in `DelayedActionTests` for:
  - **`ActionGroup` with mixed immediate + delayed actions**
  - **Separate dispatch calls with mixed immediate + delayed actions**
  - Assertions confirm:
    - the first non-delayed update is applied immediately
    - delayed updates eventually complete
    - total execution time stays roughly within the 1–2 second range

- Expanded `MiddlewareFlow` to represent new middleware scenarios:
  - `loadingTask(id:)`
  - `executeEffect(id:)`
  - `runEffect(id:)`
  - `cancelAll`

- Added new test actions to drive cancellation scenarios:
  - `RunTaskByID`
  - `ExecuteEffectByID`
  - `RunEffectByID`
  - `CancelAll`

- Introduced a dedicated test middleware, `ObservableMiddlewareToCancelAll`, that:
  - starts cancellable async work via `execute { ... }`
  - starts delayed effects via `execute(Effect(...))`
  - starts delayed effects via `run(Effect(...))`
  - invokes `cancelAll()` when the `CancelAll` action is observed

- Added bulk-cancellation tests to verify the same behavior across all execution styles:
  - `testMiddlewareCancellationAllTask`
  - `testMiddlewareCancellationAllExecuteEffect`
  - `testMiddlewareCancellationAllRunEffect`

- Each cancellation test validates that:
  - all started operations are tracked before cancellation
  - `cancelAll()` removes all tracked cancellations
  - no completion messages are applied to state after cancellation
Cover the test cases:

Test 1:
Delayed action 1
Delayed action 2
Regular action dispatch
-> See if we hang in this case

Test 2:
Simulate request from server with an async delay (sleep) in a middleware
During the delay use cancelAll method on Middleware
See if actions will still successfully dispatch after the simulated request (they should not)