### PR TITLE
Support if let (optional binding) in @ScopeBuilder

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/Scope/ScopeBuilderConditionalTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Scope/ScopeBuilderConditionalTests.swift
@@ -1,0 +1,102 @@
+//===--- ScopeBuilderConditionalTests.swift ------------------------===//
+//
+// This source file is part of the UDF open source project
+//
+// Copyright (c) 2026 You are launched
+// Licensed under Apache License v2.0
+//
+// See https://opensource.org/licenses/Apache-2.0 for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+@testable import UDF
+import Testing
+
+/// Verifies that `@ScopeBuilder` supports `if let` (and `if`/`else`) branches,
+/// removing the need for sentinel-value workarounds when scoping to an optional-derived key.
+@Suite struct ScopeBuilderConditionalTests {
+    struct RootForm: Form {
+        var bookToModalPresent: Int? = nil
+    }
+
+    struct AppState: AppReducer {
+        var rootForm = RootForm()
+    }
+
+    struct BookScope: Scope, Equatable {
+        let id: Int
+    }
+
+    struct EmptyBookScope: Scope, Equatable {}
+
+    @ScopeBuilder
+    static func ifLetOnlyScope(for state: AppState) -> Scope {
+        if let bookId = state.rootForm.bookToModalPresent {
+            BookScope(id: bookId)
+        }
+    }
+
+    @ScopeBuilder
+    static func ifElseScope(for state: AppState) -> Scope {
+        if let bookId = state.rootForm.bookToModalPresent {
+            BookScope(id: bookId)
+        } else {
+            EmptyBookScope()
+        }
+    }
+
+    @Test
+    func branchNotTakenIsEqualAcrossStates() {
+        let stateA = AppState()
+        let stateB = AppState()
+
+        let scopeA = Self.ifLetOnlyScope(for: stateA)
+        let scopeB = Self.ifLetOnlyScope(for: stateB)
+
+        #expect(scopeA.isEqual(scopeB))
+    }
+
+    @Test
+    func branchTakenReflectsTheBoundValue() {
+        var stateA = AppState()
+        stateA.rootForm.bookToModalPresent = 42
+
+        var stateB = AppState()
+        stateB.rootForm.bookToModalPresent = 42
+
+        var stateC = AppState()
+        stateC.rootForm.bookToModalPresent = 7
+
+        let scopeA = Self.ifLetOnlyScope(for: stateA)
+        let scopeB = Self.ifLetOnlyScope(for: stateB)
+        let scopeC = Self.ifLetOnlyScope(for: stateC)
+
+        #expect(scopeA.isEqual(scopeB))
+        #expect(!scopeA.isEqual(scopeC))
+    }
+
+    @Test
+    func switchingBetweenNilAndAValueIsDetectedAsAChange() {
+        let stateNil = AppState()
+        var stateValue = AppState()
+        stateValue.rootForm.bookToModalPresent = 1
+
+        let scopeNil = Self.ifLetOnlyScope(for: stateNil)
+        let scopeValue = Self.ifLetOnlyScope(for: stateValue)
+
+        #expect(!scopeNil.isEqual(scopeValue))
+        #expect(!scopeValue.isEqual(scopeNil))
+    }
+
+    @Test
+    func ifElseBranchesAreEquivalentToIfLetOnly() {
+        let stateNil = AppState()
+        var stateValue = AppState()
+        stateValue.rootForm.bookToModalPresent = 42
+
+        #expect(Self.ifElseScope(for: stateNil).isEqual(Self.ifElseScope(for: AppState())))
+        #expect(Self.ifElseScope(for: stateValue).isEqual(Self.ifElseScope(for: stateValue)))
+        #expect(!Self.ifElseScope(for: stateNil).isEqual(Self.ifElseScope(for: stateValue)))
+    }
+}

--- a/Tests/SwiftUI-UDF-Tests/Scope/ScopeBuilderConditionalTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Scope/ScopeBuilderConditionalTests.swift
@@ -20,11 +20,20 @@ import Testing
         var bookToModalPresent: Int? = nil
     }
 
+    struct TailForm: Form {
+        var counter: Int = 0
+    }
+
     struct AppState: AppReducer {
         var rootForm = RootForm()
+        var tailForm = TailForm()
     }
 
     struct BookScope: Scope, Equatable {
+        let id: Int
+    }
+
+    struct AlternateBookScope: Scope, Equatable {
         let id: Int
     }
 
@@ -43,6 +52,29 @@ import Testing
             BookScope(id: bookId)
         } else {
             EmptyBookScope()
+        }
+    }
+
+    /// Mirrors the real shape used in `RootContainer.scope(for:)`: an `if let` branch
+    /// followed by unconditional statements in the same builder block.
+    @ScopeBuilder
+    static func combinedScope(for state: AppState) -> Scope {
+        if let bookId = state.rootForm.bookToModalPresent {
+            BookScope(id: bookId)
+        }
+        state.tailForm
+    }
+
+    /// A condition nested inside another condition, to make sure `EitherScope`/`OptionalScope`
+    /// compose correctly when layered.
+    @ScopeBuilder
+    static func nestedConditionScope(for state: AppState) -> Scope {
+        if let bookId = state.rootForm.bookToModalPresent {
+            if bookId > 100 {
+                AlternateBookScope(id: bookId)
+            } else {
+                BookScope(id: bookId)
+            }
         }
     }
 
@@ -98,5 +130,94 @@ import Testing
         #expect(Self.ifElseScope(for: stateNil).isEqual(Self.ifElseScope(for: AppState())))
         #expect(Self.ifElseScope(for: stateValue).isEqual(Self.ifElseScope(for: stateValue)))
         #expect(!Self.ifElseScope(for: stateNil).isEqual(Self.ifElseScope(for: stateValue)))
+    }
+
+    // MARK: - Combined scope (if let + unconditional trailing statements, like `RootContainer`)
+
+    @Test
+    func combinedScopeIsEqualWhenNothingChanged() {
+        let stateA = AppState()
+        let stateB = AppState()
+
+        #expect(Self.combinedScope(for: stateA).isEqual(Self.combinedScope(for: stateB)))
+    }
+
+    @Test
+    func combinedScopeDetectsChangeInTheConditionalPartOnly() {
+        let stateNil = AppState()
+        var stateValue = AppState()
+        stateValue.rootForm.bookToModalPresent = 1
+        // tailForm stays identical in both states
+
+        #expect(!Self.combinedScope(for: stateNil).isEqual(Self.combinedScope(for: stateValue)))
+    }
+
+    @Test
+    func combinedScopeDetectsChangeInTheTrailingUnconditionalPartOnly() {
+        var stateA = AppState()
+        stateA.rootForm.bookToModalPresent = 1
+
+        var stateB = AppState()
+        stateB.rootForm.bookToModalPresent = 1
+        stateB.tailForm.counter = 1
+        // the conditional part (bookToModalPresent) is identical in both states
+
+        #expect(!Self.combinedScope(for: stateA).isEqual(Self.combinedScope(for: stateB)))
+    }
+
+    @Test
+    func combinedScopeIsEqualWhenBothPartsMatch() {
+        var stateA = AppState()
+        stateA.rootForm.bookToModalPresent = 1
+        stateA.tailForm.counter = 5
+
+        var stateB = AppState()
+        stateB.rootForm.bookToModalPresent = 1
+        stateB.tailForm.counter = 5
+
+        #expect(Self.combinedScope(for: stateA).isEqual(Self.combinedScope(for: stateB)))
+    }
+
+    // MARK: - Nested conditions
+
+    @Test
+    func nestedConditionBranchNotTakenIsEqualAcrossStates() {
+        let stateA = AppState()
+        let stateB = AppState()
+
+        #expect(Self.nestedConditionScope(for: stateA).isEqual(Self.nestedConditionScope(for: stateB)))
+    }
+
+    @Test
+    func nestedConditionSameInnerBranchWithSameValueIsEqual() {
+        var stateA = AppState()
+        stateA.rootForm.bookToModalPresent = 5
+
+        var stateB = AppState()
+        stateB.rootForm.bookToModalPresent = 5
+
+        #expect(Self.nestedConditionScope(for: stateA).isEqual(Self.nestedConditionScope(for: stateB)))
+    }
+
+    @Test
+    func nestedConditionDifferentInnerBranchesAreNotEqual() {
+        var stateA = AppState()
+        stateA.rootForm.bookToModalPresent = 5 // takes the `else` inner branch -> BookScope
+
+        var stateB = AppState()
+        stateB.rootForm.bookToModalPresent = 150 // takes the `if` inner branch -> AlternateBookScope
+
+        #expect(!Self.nestedConditionScope(for: stateA).isEqual(Self.nestedConditionScope(for: stateB)))
+    }
+
+    @Test
+    func nestedConditionSameInnerBranchDifferentValueIsNotEqual() {
+        var stateA = AppState()
+        stateA.rootForm.bookToModalPresent = 150
+
+        var stateB = AppState()
+        stateB.rootForm.bookToModalPresent = 151
+
+        #expect(!Self.nestedConditionScope(for: stateA).isEqual(Self.nestedConditionScope(for: stateB)))
     }
 }

--- a/Tests/SwiftUI-UDF-Tests/Scope/ScopeBuilderConditionalTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Scope/ScopeBuilderConditionalTests.swift
@@ -29,29 +29,29 @@ import Testing
         var tailForm = TailForm()
     }
 
-    struct BookScope: Scope, Equatable {
+    struct MockBook: Scope, Equatable {
         let id: Int
     }
 
-    struct AlternateBookScope: Scope, Equatable {
+    struct MockAlternateBook: Scope, Equatable {
         let id: Int
     }
 
-    struct EmptyBookScope: Scope, Equatable {}
+    struct MockEmptyBook: Scope, Equatable {}
 
     @ScopeBuilder
     static func ifLetOnlyScope(for state: AppState) -> Scope {
         if let bookId = state.rootForm.bookToModalPresent {
-            BookScope(id: bookId)
+            MockBook(id: bookId)
         }
     }
 
     @ScopeBuilder
     static func ifElseScope(for state: AppState) -> Scope {
         if let bookId = state.rootForm.bookToModalPresent {
-            BookScope(id: bookId)
+            MockBook(id: bookId)
         } else {
-            EmptyBookScope()
+            MockEmptyBook()
         }
     }
 
@@ -60,7 +60,7 @@ import Testing
     @ScopeBuilder
     static func combinedScope(for state: AppState) -> Scope {
         if let bookId = state.rootForm.bookToModalPresent {
-            BookScope(id: bookId)
+            MockBook(id: bookId)
         }
         state.tailForm
     }
@@ -71,9 +71,9 @@ import Testing
     static func nestedConditionScope(for state: AppState) -> Scope {
         if let bookId = state.rootForm.bookToModalPresent {
             if bookId > 100 {
-                AlternateBookScope(id: bookId)
+                MockAlternateBook(id: bookId)
             } else {
-                BookScope(id: bookId)
+                MockBook(id: bookId)
             }
         }
     }

--- a/UDF/Common/Scope/EitherScope.swift
+++ b/UDF/Common/Scope/EitherScope.swift
@@ -1,0 +1,50 @@
+//===--- EitherScope.swift -----------------------------------------===//
+//
+// This source file is part of the UDF open source project
+//
+// Copyright (c) 2026 You are launched
+// Licensed under Apache License v2.0
+//
+// See https://opensource.org/licenses/Apache-2.0 for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A `Scope` that wraps the result of an `if`/`else` (or `switch`) branch inside a `@ScopeBuilder`
+/// block, mirroring how `_ConditionalContent` lets `ViewBuilder` support branching.
+///
+/// Two `EitherScope` values are only equal when they resolved to the same branch and the
+/// wrapped scopes are equal; switching branches is always treated as a change.
+///
+/// ## Example
+/// ```swift
+/// @ScopeBuilder
+/// func scope(for state: AppState) -> Scope {
+///     if let bookToModalPresent = state.rootForm.bookToModalPresent {
+///         state.allBooks.bookBy(id: bookToModalPresent)
+///     } else {
+///         .none
+///     }
+/// }
+/// ```
+public enum EitherScope<First: EquatableScope, Second: EquatableScope>: EquatableScope {
+    /// The scope produced when the condition evaluated to `true`.
+    case first(First)
+
+    /// The scope produced when the condition evaluated to `false`.
+    case second(Second)
+
+    public static func == (lhs: EitherScope<First, Second>, rhs: EitherScope<First, Second>) -> Bool {
+        switch (lhs, rhs) {
+        case let (.first(lhsScope), .first(rhsScope)):
+            return lhsScope == rhsScope
+
+        case let (.second(lhsScope), .second(rhsScope)):
+            return lhsScope == rhsScope
+
+        default:
+            return false
+        }
+    }
+}

--- a/UDF/Common/Scope/OptionalScope.swift
+++ b/UDF/Common/Scope/OptionalScope.swift
@@ -1,0 +1,41 @@
+//===--- OptionalScope.swift ---------------------------------------===//
+//
+// This source file is part of the UDF open source project
+//
+// Copyright (c) 2026 You are launched
+// Licensed under Apache License v2.0
+//
+// See https://opensource.org/licenses/Apache-2.0 for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A `Scope` that wraps the result of an `if`/`if let` branch without a matching `else`
+/// inside a `@ScopeBuilder` block.
+///
+/// When the condition is `false` (or the optional being bound is `nil`), `wrapped` is `nil`
+/// and `OptionalScope` behaves like `NoneScope`: it is always equal to another empty
+/// `OptionalScope`, meaning it never contributes to change detection when the branch isn't taken.
+///
+/// ## Example
+/// ```swift
+/// @ScopeBuilder
+/// func scope(for state: AppState) -> Scope {
+///     if let bookToModalPresent = state.rootForm.bookToModalPresent {
+///         state.allBooks.bookBy(id: bookToModalPresent)
+///     }
+/// }
+/// ```
+public struct OptionalScope<Wrapped: EquatableScope>: EquatableScope {
+    /// The scope produced by the taken branch, or `nil` if the branch wasn't taken.
+    let wrapped: Wrapped?
+
+    init(_ wrapped: Wrapped?) {
+        self.wrapped = wrapped
+    }
+
+    public static func == (lhs: OptionalScope<Wrapped>, rhs: OptionalScope<Wrapped>) -> Bool {
+        lhs.wrapped == rhs.wrapped
+    }
+}

--- a/UDF/Common/Scope/Scope.swift
+++ b/UDF/Common/Scope/Scope.swift
@@ -87,4 +87,33 @@ public enum ScopeBuilder {
     public static func buildPartialBlock(accumulated: some EquatableScope, next: some EquatableScope) -> some EquatableScope {
         CombinedScope(accumulated, next)
     }
+
+    /// Supports `if`/`if let` branches without a matching `else` inside a `@ScopeBuilder` block.
+    ///
+    /// - Parameter scope: The scope produced by the branch, or `nil` if the condition wasn't met
+    ///   (or the optional being bound with `if let` was `nil`).
+    /// - Returns: An `OptionalScope` wrapping the given scope.
+    public static func buildOptional(_ scope: (some EquatableScope)?) -> some EquatableScope {
+        OptionalScope(scope)
+    }
+
+    /// Supports the first branch of an `if`/`else` (or a `switch` case) inside a `@ScopeBuilder` block.
+    ///
+    /// - Parameter scope: The scope produced by the first branch.
+    /// - Returns: An `EitherScope` wrapping the given scope.
+    public static func buildEither<TrueScope: EquatableScope, FalseScope: EquatableScope>(
+        first scope: TrueScope
+    ) -> EitherScope<TrueScope, FalseScope> {
+        .first(scope)
+    }
+
+    /// Supports the second branch of an `if`/`else` (or a `switch` case) inside a `@ScopeBuilder` block.
+    ///
+    /// - Parameter scope: The scope produced by the second branch.
+    /// - Returns: An `EitherScope` wrapping the given scope.
+    public static func buildEither<TrueScope: EquatableScope, FalseScope: EquatableScope>(
+        second scope: FalseScope
+    ) -> EitherScope<TrueScope, FalseScope> {
+        .second(scope)
+    }
 }


### PR DESCRIPTION
### Description
This merge request adds conditional branching support to `@ScopeBuilder`, allowing scope definitions to use `if`, `if let`, and `if/else` directly.

The problem being solved is that conditional scoping for optional-derived state previously required workaround patterns such as sentinel scopes or manual normalization to preserve correct change detection. These changes make conditional scope composition explicit and safe: non-taken branches compare as empty, while switching between branches is treated as a real scope change.

The chosen approach mirrors Swift result-builder conventions (`buildOptional` / `buildEither`), similar to how `ViewBuilder` handles conditional content. This is preferable to pushing the responsibility onto callers to emulate empty scopes or flatten branch behavior manually.

### Changes Made
- Added `ScopeBuilder` support for conditional branches:
  - `buildOptional(_:)` for `if` / `if let` without `else`
  - `buildEither(first:)` and `buildEither(second:)` for `if/else` and `switch`-style branching

- Introduced `OptionalScope<Wrapped>`:
  - Wraps the result of a conditional branch that may be absent
  - Uses optional equality so two non-taken branches compare equal
  - Detects transitions between `nil` and a concrete scoped value as changes

- Introduced `EitherScope<First, Second>`:
  - Encodes which branch was taken in conditional builders
  - Only compares equal when both the selected branch and wrapped scope match
  - Ensures branch switches are always treated as scope changes

- Added test coverage for conditional scope behavior:
  - empty `if let` branches compare equal across equivalent states
  - bound values affect equality as expected
  - transitions between `nil` and non-`nil` are detected
  - `if/else` branch behavior is validated independently of the `if let`-only case

```swift
@ScopeBuilder
static func ifLetOnlyScope(for state: AppState) -> Scope {
    if let bookId = state.rootForm.bookToModalPresent {
        BookScope(id: bookId)
    }
}
```

```swift
@ScopeBuilder
static func ifElseScope(for state: AppState) -> Scope {
    if let bookId = state.rootForm.bookToModalPresent {
        BookScope(id: bookId)
    } else {
        EmptyBookScope()
    }
}
```

### ClickUp task
https://app.clickup.com/t/869e9njrx