### PR TITLE
test(Scope): cover container scoped to a single collection item

### DIFF
--- a/Tests/SwiftUI-UDF-ConcurrencyTests/ContainersRedrawing/ContainerScopedToCollectionItemTests.swift
+++ b/Tests/SwiftUI-UDF-ConcurrencyTests/ContainersRedrawing/ContainerScopedToCollectionItemTests.swift
@@ -54,7 +54,7 @@ import UDFSwiftTesting
 
         mutating func reduce(_ action: some Action) {
             switch action {
-            case let action as TestActions.LoadItem:
+            case let action as Actions.DidLoadItem<Item>:
                 byId[action.item.id] = action.item
             case let action as TestActions.UpdateItemTitle:
                 byId[action.id]?.title = action.title
@@ -72,10 +72,6 @@ import UDFSwiftTesting
     }
 
     enum TestActions {
-        struct LoadItem: Action {
-            let item: Item
-        }
-
         struct UpdateItemTitle: Action {
             let id: Item.ID
             let title: String
@@ -101,7 +97,7 @@ import UDFSwiftTesting
         let container = ItemContainer(itemId: .init(value: 1))
         let window = await PlatformWindow.render(view: container.with(store: store))
 
-        var success = await waitForMainActorCondition { container.renderingNumber == 1 }
+        var success = await waitForMainActorCondition { container.renderingCount == 1 }
         #expect(success)
 
         // Mutate a *different* item in the same collection.
@@ -110,16 +106,19 @@ import UDFSwiftTesting
 
         window.redraw()
         // Give the run loop a beat, then assert the count did NOT advance.
-        success = await waitForMainActorCondition { container.renderingNumber == 1 }
+        success = await waitForMainActorCondition { container.renderingCount == 1 }
         #expect(success)
-        #expect(container.renderingNumber == 1)
+        #expect(container.renderingCount == 1)
     }
 
     @Test
     @MainActor func targetItemChangeRedraws() async {
+        // Two items present -> proves diffing reacts to the *specific* item,
+        // not just to "the store has any content".
         let initialState = AppState(
             items: ItemsStore(byId: [
-                .init(value: 1): .init(id: .init(value: 1), title: "target")
+                .init(value: 1): .init(id: .init(value: 1), title: "target"),
+                .init(value: 2): .init(id: .init(value: 2), title: "other")
             ])
         )
         let store = EnvironmentStore(initial: initialState, logger: TestStoreLogger())
@@ -127,14 +126,14 @@ import UDFSwiftTesting
         let container = ItemContainer(itemId: .init(value: 1))
         let window = await PlatformWindow.render(view: container.with(store: store))
 
-        var success = await waitForMainActorCondition { container.renderingNumber == 1 }
+        var success = await waitForMainActorCondition { container.renderingCount == 1 }
         #expect(success)
 
         store.dispatch(TestActions.UpdateItemTitle(id: .init(value: 1), title: "target changed"))
         await waitForMainActorCondition { store.state.items.byId[.init(value: 1)]?.title == "target changed" }
 
         window.redraw()
-        success = await waitForMainActorCondition { container.renderingNumber == 2 }
+        success = await waitForMainActorCondition { container.renderingCount == 2 }
         #expect(success)
     }
 
@@ -146,23 +145,26 @@ import UDFSwiftTesting
         let container = ItemContainer(itemId: .init(value: 1))
         let window = await PlatformWindow.render(view: container.with(store: store))
 
-        var success = await waitForMainActorCondition { container.renderingNumber == 1 }
+        var success = await waitForMainActorCondition { container.renderingCount == 1 }
         #expect(success)
-        #expect(container.renderingNumber == 1) // rendered once with `.empty`
+        #expect(container.renderingCount == 1) // rendered once with `.empty`
 
-        store.dispatch(TestActions.LoadItem(item: .init(id: .init(value: 1), title: "loaded")))
+        store.dispatch(Actions.DidLoadItem(item: Item(id: .init(value: 1), title: "loaded")))
         await waitForMainActorCondition { store.state.items.byId[.init(value: 1)] != nil }
 
         window.redraw()
-        success = await waitForMainActorCondition { container.renderingNumber == 2 }
+        success = await waitForMainActorCondition { container.renderingCount == 2 }
         #expect(success)
     }
 
     @Test
     @MainActor func targetItemRemovalRedraws() async {
+        // Two items present -> proves removal-driven redraw isn't just an
+        // artifact of the store becoming empty overall.
         let initialState = AppState(
             items: ItemsStore(byId: [
-                .init(value: 1): .init(id: .init(value: 1), title: "target")
+                .init(value: 1): .init(id: .init(value: 1), title: "target"),
+                .init(value: 2): .init(id: .init(value: 2), title: "other")
             ])
         )
         let store = EnvironmentStore(initial: initialState, logger: TestStoreLogger())
@@ -170,7 +172,7 @@ import UDFSwiftTesting
         let container = ItemContainer(itemId: .init(value: 1))
         let window = await PlatformWindow.render(view: container.with(store: store))
 
-        var success = await waitForMainActorCondition { container.renderingNumber == 1 }
+        var success = await waitForMainActorCondition { container.renderingCount == 1 }
         #expect(success)
 
         store.dispatch(TestActions.RemoveItem(id: .init(value: 1)))
@@ -178,8 +180,11 @@ import UDFSwiftTesting
 
         window.redraw()
         // itemBy(id:) now resolves to .empty -> Scope must change -> redraw fires again.
-        success = await waitForMainActorCondition { container.renderingNumber == 2 }
+        success = await waitForMainActorCondition { container.renderingCount == 2 }
         #expect(success)
+        // The unrelated item must still be present -> confirms the redraw was
+        // driven by the target's removal, not by the store becoming empty.
+        #expect(store.state.items.byId[.init(value: 2)] != nil)
     }
 
     // Mirrors the real containers' shape: `Scope` combines the collection-scoped item
@@ -197,21 +202,21 @@ import UDFSwiftTesting
         let container = CombinedScopeItemContainer(itemId: .init(value: 1))
         let window = await PlatformWindow.render(view: container.with(store: store))
 
-        var success = await waitForMainActorCondition { container.renderingNumber == 1 }
+        var success = await waitForMainActorCondition { container.renderingCount == 1 }
         #expect(success)
 
         // Part 1 of the combined scope changes -> must redraw.
         store.dispatch(TestActions.UpdateItemTitle(id: .init(value: 1), title: "target changed"))
         await waitForMainActorCondition { store.state.items.byId[.init(value: 1)]?.title == "target changed" }
         window.redraw()
-        success = await waitForMainActorCondition { container.renderingNumber == 2 }
+        success = await waitForMainActorCondition { container.renderingCount == 2 }
         #expect(success)
 
         // Part 2 of the combined scope changes -> must also redraw.
         store.dispatch(Actions.UpdateFormField(keyPath: \SideForm.flag, value: true))
         await waitForMainActorCondition { store.state.sideForm.flag == true }
         window.redraw()
-        success = await waitForMainActorCondition { container.renderingNumber == 3 }
+        success = await waitForMainActorCondition { container.renderingCount == 3 }
         #expect(success)
 
         // A different, unrelated item changes -> neither part of the combined scope
@@ -219,9 +224,9 @@ import UDFSwiftTesting
         store.dispatch(TestActions.UpdateItemTitle(id: .init(value: 2), title: "other changed"))
         await waitForMainActorCondition { store.state.items.byId[.init(value: 2)]?.title == "other changed" }
         window.redraw()
-        success = await waitForMainActorCondition { container.renderingNumber == 3 }
+        success = await waitForMainActorCondition { container.renderingCount == 3 }
         #expect(success)
-        #expect(container.renderingNumber == 3)
+        #expect(container.renderingCount == 3)
     }
 }
 
@@ -233,15 +238,15 @@ extension ContainerScopedToCollectionItemTests {
 
         let itemId: Item.ID
 
-        @Box var renderingNumber: Int = 0
+        @Box var renderingCount: Int = 0
 
         func scope(for state: AppState) -> Scope {
             state.items.itemBy(id: itemId)
         }
 
         func map(store: EnvironmentStore<AppState>) -> ContainerComponent.Props {
-            renderingNumber += 1
-            print("ItemContainer: renderingNumber - \(renderingNumber)")
+            renderingCount += 1
+            print("ItemContainer: renderingCount - \(renderingCount)")
 
             return .init(title: store.state.items.itemBy(id: itemId).title)
         }
@@ -266,7 +271,7 @@ extension ContainerScopedToCollectionItemTests {
 
         let itemId: Item.ID
 
-        @Box var renderingNumber: Int = 0
+        @Box var renderingCount: Int = 0
 
         func scope(for state: AppState) -> Scope {
             state.items.itemBy(id: itemId)
@@ -274,8 +279,8 @@ extension ContainerScopedToCollectionItemTests {
         }
 
         func map(store: EnvironmentStore<AppState>) -> ContainerComponent.Props {
-            renderingNumber += 1
-            print("CombinedScopeItemContainer: renderingNumber - \(renderingNumber)")
+            renderingCount += 1
+            print("CombinedScopeItemContainer: renderingCount - \(renderingCount)")
 
             return .init(title: store.state.items.itemBy(id: itemId).title)
         }

--- a/Tests/SwiftUI-UDF-ConcurrencyTests/ContainersRedrawing/ContainerScopedToCollectionItemTests.swift
+++ b/Tests/SwiftUI-UDF-ConcurrencyTests/ContainersRedrawing/ContainerScopedToCollectionItemTests.swift
@@ -1,0 +1,283 @@
+import SwiftUI
+@testable import UDF
+import Testing
+import UDFSwiftTesting
+
+@Suite struct ContainerScopedToCollectionItemTests {
+    @propertyWrapper
+    final class Box<Value> {
+        private var box: Value
+
+        init(wrappedValue: Value) {
+            box = wrappedValue
+        }
+
+        var wrappedValue: Value {
+            get { box }
+            set { box = newValue }
+        }
+    }
+
+    private struct TestStoreLogger: ActionLogger {
+        var actionFilters: [ActionFilter] = [VerboseActionFilter()]
+        var actionDescriptor: ActionDescriptor = StringDescribingActionDescriptor()
+
+        func log(_ action: LoggingAction, description: String) {
+            print("Reduce\t\t", description)
+        }
+    }
+
+    // MARK: - State
+
+    struct AppState: AppReducer {
+        var items = ItemsStore()
+        var sideForm = SideForm()
+    }
+
+    struct Item: Identifiable, Equatable, Scope {
+        struct ID: Hashable { var value: Int }
+
+        var id: ID
+        var title: String
+
+        static var empty: Item { .init(id: .init(value: -1), title: "") }
+    }
+
+    // A second field alongside the collection, mirroring how real containers combine
+    // `state.allBooks.bookBy(id:)` with `state.bookForm`, `state.userForm`, etc.
+    struct SideForm: UDF.Form {
+        var flag: Bool = false
+    }
+
+    struct ItemsStore: Reducible {
+        var byId: [Item.ID: Item] = [:]
+
+        mutating func reduce(_ action: some Action) {
+            switch action {
+            case let action as TestActions.LoadItem:
+                byId[action.item.id] = action.item
+            case let action as TestActions.UpdateItemTitle:
+                byId[action.id]?.title = action.title
+            case let action as TestActions.RemoveItem:
+                byId.removeValue(forKey: action.id)
+            default:
+                break
+            }
+        }
+
+        // Mirrors `AllBooks.bookBy(id:)` from the app: non-optional, falls back to `.empty`.
+        func itemBy(id: Item.ID) -> Item {
+            byId[id] ?? .empty
+        }
+    }
+
+    enum TestActions {
+        struct LoadItem: Action {
+            let item: Item
+        }
+
+        struct UpdateItemTitle: Action {
+            let id: Item.ID
+            let title: String
+        }
+
+        struct RemoveItem: Action {
+            let id: Item.ID
+        }
+    }
+
+    // MARK: - Tests
+
+    @Test
+    @MainActor func unrelatedItemChangeDoesNotRedraw() async {
+        let initialState = AppState(
+            items: ItemsStore(byId: [
+                .init(value: 1): .init(id: .init(value: 1), title: "target"),
+                .init(value: 2): .init(id: .init(value: 2), title: "other")
+            ])
+        )
+        let store = EnvironmentStore(initial: initialState, logger: TestStoreLogger())
+
+        let container = ItemContainer(itemId: .init(value: 1))
+        let window = await PlatformWindow.render(view: container.with(store: store))
+
+        var success = await waitForMainActorCondition { container.renderingNumber == 1 }
+        #expect(success)
+
+        // Mutate a *different* item in the same collection.
+        store.dispatch(TestActions.UpdateItemTitle(id: .init(value: 2), title: "other changed"))
+        await waitForMainActorCondition { store.state.items.byId[.init(value: 2)]?.title == "other changed" }
+
+        window.redraw()
+        // Give the run loop a beat, then assert the count did NOT advance.
+        success = await waitForMainActorCondition { container.renderingNumber == 1 }
+        #expect(success)
+        #expect(container.renderingNumber == 1)
+    }
+
+    @Test
+    @MainActor func targetItemChangeRedraws() async {
+        let initialState = AppState(
+            items: ItemsStore(byId: [
+                .init(value: 1): .init(id: .init(value: 1), title: "target")
+            ])
+        )
+        let store = EnvironmentStore(initial: initialState, logger: TestStoreLogger())
+
+        let container = ItemContainer(itemId: .init(value: 1))
+        let window = await PlatformWindow.render(view: container.with(store: store))
+
+        var success = await waitForMainActorCondition { container.renderingNumber == 1 }
+        #expect(success)
+
+        store.dispatch(TestActions.UpdateItemTitle(id: .init(value: 1), title: "target changed"))
+        await waitForMainActorCondition { store.state.items.byId[.init(value: 1)]?.title == "target changed" }
+
+        window.redraw()
+        success = await waitForMainActorCondition { container.renderingNumber == 2 }
+        #expect(success)
+    }
+
+    @Test
+    @MainActor func targetItemLoadingFromEmptyRedraws() async {
+        // Item not present yet -> itemBy(id:) resolves to .empty.
+        let store = EnvironmentStore(initial: AppState(), logger: TestStoreLogger())
+
+        let container = ItemContainer(itemId: .init(value: 1))
+        let window = await PlatformWindow.render(view: container.with(store: store))
+
+        var success = await waitForMainActorCondition { container.renderingNumber == 1 }
+        #expect(success)
+        #expect(container.renderingNumber == 1) // rendered once with `.empty`
+
+        store.dispatch(TestActions.LoadItem(item: .init(id: .init(value: 1), title: "loaded")))
+        await waitForMainActorCondition { store.state.items.byId[.init(value: 1)] != nil }
+
+        window.redraw()
+        success = await waitForMainActorCondition { container.renderingNumber == 2 }
+        #expect(success)
+    }
+
+    @Test
+    @MainActor func targetItemRemovalRedraws() async {
+        let initialState = AppState(
+            items: ItemsStore(byId: [
+                .init(value: 1): .init(id: .init(value: 1), title: "target")
+            ])
+        )
+        let store = EnvironmentStore(initial: initialState, logger: TestStoreLogger())
+
+        let container = ItemContainer(itemId: .init(value: 1))
+        let window = await PlatformWindow.render(view: container.with(store: store))
+
+        var success = await waitForMainActorCondition { container.renderingNumber == 1 }
+        #expect(success)
+
+        store.dispatch(TestActions.RemoveItem(id: .init(value: 1)))
+        await waitForMainActorCondition { store.state.items.byId[.init(value: 1)] == nil }
+
+        window.redraw()
+        // itemBy(id:) now resolves to .empty -> Scope must change -> redraw fires again.
+        success = await waitForMainActorCondition { container.renderingNumber == 2 }
+        #expect(success)
+    }
+
+    // Mirrors the real containers' shape: `Scope` combines the collection-scoped item
+    // together with another, unrelated piece of state (like `bookForm`/`userForm`).
+    @Test
+    @MainActor func combinedScopePartsRedrawIndependently() async {
+        let initialState = AppState(
+            items: ItemsStore(byId: [
+                .init(value: 1): .init(id: .init(value: 1), title: "target"),
+                .init(value: 2): .init(id: .init(value: 2), title: "other")
+            ])
+        )
+        let store = EnvironmentStore(initial: initialState, logger: TestStoreLogger())
+
+        let container = CombinedScopeItemContainer(itemId: .init(value: 1))
+        let window = await PlatformWindow.render(view: container.with(store: store))
+
+        var success = await waitForMainActorCondition { container.renderingNumber == 1 }
+        #expect(success)
+
+        // Part 1 of the combined scope changes -> must redraw.
+        store.dispatch(TestActions.UpdateItemTitle(id: .init(value: 1), title: "target changed"))
+        await waitForMainActorCondition { store.state.items.byId[.init(value: 1)]?.title == "target changed" }
+        window.redraw()
+        success = await waitForMainActorCondition { container.renderingNumber == 2 }
+        #expect(success)
+
+        // Part 2 of the combined scope changes -> must also redraw.
+        store.dispatch(Actions.UpdateFormField(keyPath: \SideForm.flag, value: true))
+        await waitForMainActorCondition { store.state.sideForm.flag == true }
+        window.redraw()
+        success = await waitForMainActorCondition { container.renderingNumber == 3 }
+        #expect(success)
+
+        // A different, unrelated item changes -> neither part of the combined scope
+        // is affected -> must NOT redraw.
+        store.dispatch(TestActions.UpdateItemTitle(id: .init(value: 2), title: "other changed"))
+        await waitForMainActorCondition { store.state.items.byId[.init(value: 2)]?.title == "other changed" }
+        window.redraw()
+        success = await waitForMainActorCondition { container.renderingNumber == 3 }
+        #expect(success)
+        #expect(container.renderingNumber == 3)
+    }
+}
+
+// MARK: - ItemContainer
+
+extension ContainerScopedToCollectionItemTests {
+    struct ItemContainer: Container {
+        typealias ContainerComponent = ItemComponent
+
+        let itemId: Item.ID
+
+        @Box var renderingNumber: Int = 0
+
+        func scope(for state: AppState) -> Scope {
+            state.items.itemBy(id: itemId)
+        }
+
+        func map(store: EnvironmentStore<AppState>) -> ContainerComponent.Props {
+            renderingNumber += 1
+            print("ItemContainer: renderingNumber - \(renderingNumber)")
+
+            return .init(title: store.state.items.itemBy(id: itemId).title)
+        }
+    }
+
+    struct ItemComponent: Component {
+        struct Props {
+            var title: String
+        }
+
+        var props: Props
+
+        var body: some View {
+            Text(props.title)
+        }
+    }
+
+    // MARK: - CombinedScopeItemContainer
+
+    struct CombinedScopeItemContainer: Container {
+        typealias ContainerComponent = ItemComponent
+
+        let itemId: Item.ID
+
+        @Box var renderingNumber: Int = 0
+
+        func scope(for state: AppState) -> Scope {
+            state.items.itemBy(id: itemId)
+            state.sideForm
+        }
+
+        func map(store: EnvironmentStore<AppState>) -> ContainerComponent.Props {
+            renderingNumber += 1
+            print("CombinedScopeItemContainer: renderingNumber - \(renderingNumber)")
+
+            return .init(title: store.state.items.itemBy(id: itemId).title)
+        }
+    }
+}


### PR DESCRIPTION
### Description
This merge request adds concurrency-focused redraw tests for containers scoped to a single item inside a collection.

The tests target a regression-prone case where a container derives its scope from `state.items.itemBy(id:)` instead of holding the item directly. The goal is to verify that redraws are triggered only when the scoped item actually changes, including transitions between a missing item and the `.empty` fallback, while ignoring mutations to other collection entries.

These checks are necessary because real screens often combine a collection-derived entity with unrelated state such as a form. Without explicit coverage, changes elsewhere in the same collection could cause unnecessary redraws, or item load/remove flows could fail to refresh the container.

An alternative would be broader redraw tests at the store or screen level, but those would not isolate the collection-item scoping behavior or validate fallback-based scope changes precisely.

### Changes Made
- Added a new test suite: `ContainerScopedToCollectionItemTests`.
- Introduced a minimal app model to reproduce the real scoping pattern:
  - `AppState` containing:
    - `ItemsStore` backed by `byId`
    - `SideForm` as unrelated parallel state
  - `ItemsStore.itemBy(id:)` returning a non-optional item with `.empty` fallback
- Added item-specific test actions:
  - `LoadItem`
  - `UpdateItemTitle`
  - `RemoveItem`

- Added redraw verification for item-scoped containers:
  - changing a different item does **not** redraw
  - changing the target item **does** redraw
  - loading a previously missing target item (`.empty -> actual item`) **does** redraw
  - removing the target item (`actual item -> .empty`) **does** redraw

- Added coverage for combined scopes with both:
  - a collection-scoped item
  - unrelated form state  
  This verifies each scoped part redraws independently, while unrelated item updates still do not trigger redraws.

- Added lightweight test containers/components to count renders and assert redraw behavior:
  ```swift
  func scope(for state: AppState) -> Scope {
      state.items.itemBy(id: itemId)
  }
  ```

  ```swift
  func scope(for state: AppState) -> Scope {
      state.items.itemBy(id: itemId)
      state.sideForm
  }
  ```

- Included test-only helpers:
  - `Box` property wrapper for mutable render counters inside containers
  - `TestStoreLogger` for action logging during test execution

### ClickUp task
https://app.clickup.com/t/869e9rkzp