### PR TITLE
Add Cached.flush() to allow bypassing the debounce for critical writes

### DIFF
--- a/UDF/Common/Cached/Cached.swift
+++ b/UDF/Common/Cached/Cached.swift
@@ -106,6 +106,13 @@ public struct Cached<T: Codable & Sendable>: Initable, Sendable {
         storage.remove()
         wrappedValue = defaultValue
     }
+
+    /// Immediately persists the current in-memory value to storage, bypassing the debounce interval.
+    /// Use this at critical lifecycle points (app backgrounding, termination) where waiting
+    /// for the debounced write could lose data.
+    public func flush() {
+        storage.save(inMemoryValue)
+    }
 }
 
 /// Extends `Cached` to conform to `IsEquatable` where the cached type `T` conforms to both `Reducing` and `Equatable`.


### PR DESCRIPTION
### Description
This merge request adds a way to force immediate persistence of a `Cached` value instead of waiting for the existing debounced save behavior.

This solves a data-loss risk during critical app lifecycle events such as backgrounding or termination, where in-memory changes may not be written to storage before the process is suspended or killed. The change is necessary because debounce-based persistence is efficient during normal operation, but it is not reliable when the app is about to stop running.

An alternative would be to shorten or remove the debounce window globally, but that would increase write frequency and reduce the benefit of the current caching strategy. This change keeps the existing behavior while adding an explicit escape hatch for urgent persistence.

### Changes Made
- Added a new public `flush()` method to `Cached`.
- `flush()` writes the current `inMemoryValue` directly to storage via `storage.save(inMemoryValue)`.
- Documented the intended usage: call it during critical lifecycle transitions to avoid losing pending cached updates.
### Problem

`Cached<T>` persists its wrapped value through a `Debouncer`, which delays the actual `storage.save()` call by `intervalToSync` (default 1 second) on a background queue. This is the right default for frequently-updated values, but it means there's no way for a consumer to guarantee that a just-set value has actually reached disk.

In practice this caused a real bug downstream (Librarius): audio playback progress was written to a `@Cached` field on pause/stop/backgrounding, but if the app was force-quit shortly after, the debounced write hadn't fired yet, and the value was lost — even though the code had already dispatched the update. This was invisible in normal usage (the debounce window is short) but reliably reproducible offline, where there was no other retry path to recover the lost write.

### Change

Adds a `flush()` method to `Cached`:

```swift
public func flush() {
    storage.save(inMemoryValue)
}
```

This bypasses the `Debouncer` entirely and writes the current in-memory value straight to `storage`. It doesn't change any existing behavior — `wrappedValue`'s setter still goes through the debouncer as before. `flush()` is opt-in, called explicitly by consumers at points where they know the process might not survive long enough for the debounce to fire (e.g. `sceneWillResignActive`, before dismissing a player, etc).

### Why not change the debounce itself

Considered making `intervalToSync` lower or forcing a flush inside `Debouncer` itself, but:
- Lowering the interval globally would affect every `@Cached` consumer in the app, including ones that genuinely benefit from batching frequent writes.
- Adding a forced-flush to `Debouncer` directly would change a shared, generic primitive used across the framework, with wider blast radius and thread-safety considerations (the debounce work item is cancelled/rescheduled internally; flushing it correctly would need care).

`Cached.flush()` is additive, low-risk, and lets each consumer decide when the guarantee is worth the extra (synchronous) write.

### Impact

- No behavior change for existing consumers who don't call `flush()`.
- `flush()` performs a synchronous `storage.save()` — callers invoking it from the main thread (e.g. `sceneWillResignActive`) should be aware this is a blocking file write, though for small `Codable` payloads this is expected to be sub-millisecond in practice.

### Testing

Manually verified with the Librarius audio player: reproduced the original bug (offline pause → force-quit within ~2s → progress lost on relaunch), confirmed calling `flush()` immediately after the write eliminates the loss.