### PR TITLE
Fix: redundant scope computation in ContainerState.init

### DIFF
--- a/UDF/View/Container/ContainerState.swift
+++ b/UDF/View/Container/ContainerState.swift
@@ -58,14 +58,13 @@ final class ContainerState<State: AppReducer>: ObservableObject, @unchecked Send
 
         // Subscribe to state changes in the store
         self.subscriptionKey = store.add { [weak self] oldState, newState, animation in
-            let oldScope = scope(oldState)
             let newScope = scope(newState)
 
             // Update the scope if it has changed
-            if !oldScope.isEqual(newScope) {
-                withAnimation(animation) {
-                    self?.currentScope = newScope
-                }
+            guard let self else { return }
+            if let old = self.currentScope, old.isEqual(newScope) { return }
+            withAnimation(animation) {
+                self.currentScope = newScope
             }
         }
     }

--- a/UDF/View/Container/ContainerState.swift
+++ b/UDF/View/Container/ContainerState.swift
@@ -58,10 +58,9 @@ final class ContainerState<State: AppReducer>: ObservableObject, @unchecked Send
 
         // Subscribe to state changes in the store
         self.subscriptionKey = store.add { [weak self] oldState, newState, animation in
-            let newScope = scope(newState)
-
-            // Update the scope if it has changed
             guard let self else { return }
+            let newScope = scope(newState)
+            // Skip if the scope hasn't changed
             if let old = self.currentScope, old.isEqual(newScope) { return }
             withAnimation(animation) {
                 self.currentScope = newScope


### PR DESCRIPTION
### Description
This merge request fixes how `ContainerState` decides whether to publish scoped state updates from the store.

Previously, the comparison used `oldState` and `newState` from the store callback. That can miss the real source of truth for the view layer: `currentScope` already held by `ContainerState`. If `currentScope` had diverged from `scope(oldState)` for any reason, the update logic could make the wrong decision and either trigger unnecessary UI updates or skip needed ones.

The new approach compares the incoming scoped state against the currently stored scope before updating. This makes the observable state transition logic more reliable and aligns the equality check with the actual value exposed to SwiftUI.

### Changes Made
- Reworked the store subscription update logic in `ContainerState`:
  - removed the derived `oldScope = scope(oldState)` comparison
  - added a strong `self` unwrap via `guard let self else { return }`
  - compared `newScope` against `self.currentScope` instead of `scope(oldState)`
- Added an early return when the currently published scope is already equal to the new scoped state:
  ```swift
  if let old = self.currentScope, old.isEqual(newScope) { return }
  ```
- Kept the scoped state assignment inside `withAnimation(animation)` so UI updates still respect the store-provided animation context.
**Subject: ContainerState.init optimization in SwiftUI-UDF — fix redundant scope computation**

**Problem:** In `ContainerState.init`, on every Store dispatch, for every live Container, `scope` was computed twice — once for `oldState` and once for `newState` — just to compare them:

```swift
let oldScope = scope(oldState)
let newScope = scope(newState)
if !oldScope.isEqual(newScope) { ... }
```

The `oldScope` value for the current call is effectively the same value that was already computed and stored as `newScope` (now `currentScope`) on the previous call. So one of the two computations is purely redundant.

**Fix:** compare the new scope against the already-stored `currentScope`, instead of recomputing it from `oldState`:

```swift
let newScope = scope(newState)
if let old = self.currentScope, old.isEqual(newScope) { return }
self.currentScope = newScope
```

**Effect:** halves the number of `scope(for:)` calls on every dispatch, for every container in the app. Especially noticeable where the scope is composed of several sources (forms, reducers) — like `BookDetailsContainer`, whose scope has eight components.

**Risk:** minimal — the comparison logic is the same, only the redundant computation is removed. Container behavior (when the Component actually redraws) doesn't change.