### PR TITLE
Fix test reducibleMiddlewareToCancelDelayedAction

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
@@ -112,30 +112,6 @@ import Foundation
         success = await store.state.middlewareFlow == .none
         #expect(success)
     }
-
-    @Test func reducibleMiddlewareToCancelDelayedAction() async throws {
-        let store = await TestStore(initial: AppState())
-        var middleware: ReducibleMiddlewareToCancel?
-        await store.subscribe { store in
-            let reducibleMiddlewareToCancel = ReducibleMiddlewareToCancel(store: store, environment: .init())
-            middleware = reducibleMiddlewareToCancel
-            return [reducibleMiddlewareToCancel]
-        }
-        
-        let reducibleMiddlewareToCancel = try #require(middleware)
-        await store.dispatch(Actions.Loading())
-        var success = await waitForCondition { await store.state.middlewareFlow == .loading }
-        #expect(success)
-        
-        // Wait until the middleware starts reducibleMessage effect.
-        await waitForCondition { reducibleMiddlewareToCancel.cancellations[ReducibleMiddlewareToCancel.Сancellation.reducibleMessage] != nil }
-        
-        await store.dispatch(Actions.CancelLoading())
-        
-        success = await waitForCondition { await store.state.middlewareFlow == .none }
-        
-        #expect(success)
-    }
     
     @Test func testMiddlewareCancellationDataRace() async {
         let store = await TestStore(initial: AppState())

--- a/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Middlewares/MiddlewareCancellationTests.swift
@@ -113,17 +113,27 @@ import Foundation
         #expect(success)
     }
 
-    @Test func reducibleMiddlewareToCancel() async {
+    @Test func reducibleMiddlewareToCancelDelayedAction() async throws {
         let store = await TestStore(initial: AppState())
-        await store.subscribe(ReducibleMiddlewareToCancel.self, environment: ReducibleMiddlewareToCancel.Environment())
-        await store.dispatch(Actions.Loading())
-        var success = await store.state.middlewareFlow == .loading
-        #expect(success)
-
-        await store.dispatch(Actions.CancelLoading())
-        await store.wait()
+        var middleware: ReducibleMiddlewareToCancel?
+        await store.subscribe { store in
+            let reducibleMiddlewareToCancel = ReducibleMiddlewareToCancel(store: store, environment: .init())
+            middleware = reducibleMiddlewareToCancel
+            return [reducibleMiddlewareToCancel]
+        }
         
-        success = await store.state.middlewareFlow == .none
+        let reducibleMiddlewareToCancel = try #require(middleware)
+        await store.dispatch(Actions.Loading())
+        var success = await waitForCondition { await store.state.middlewareFlow == .loading }
+        #expect(success)
+        
+        // Wait until the middleware starts reducibleMessage effect.
+        await waitForCondition { reducibleMiddlewareToCancel.cancellations[ReducibleMiddlewareToCancel.Сancellation.reducibleMessage] != nil }
+        
+        await store.dispatch(Actions.CancelLoading())
+        
+        success = await waitForCondition { await store.state.middlewareFlow == .none }
+        
         #expect(success)
     }
     


### PR DESCRIPTION
### Description
This merge request fixes a timing-sensitive cancellation test for `ReducibleMiddlewareToCancel`. The previous test assumed the cancellable effect was already registered by the time `CancelLoading()` was dispatched, which could lead to flaky behavior when the delayed action had not started yet.

The change makes the test explicitly wait for the middleware’s cancellable `reducibleMessage` effect to be created before issuing the cancellation. This is necessary to verify actual cancellation of the delayed action rather than relying on race-prone execution order.

An alternative would have been to keep using generic store synchronization (`wait()`), but that does not guarantee the cancellation token exists before cancellation is triggered.

### Changes Made
- Renamed the test from `reducibleMiddlewareToCancel` to `reducibleMiddlewareToCancelDelayedAction` to reflect the delayed-effect cancellation scenario being validated.
- Switched middleware subscription from type-based registration to explicit construction inside a subscription closure so the test can retain a reference to the middleware instance.
- Added a required unwrap of the middleware instance:
  ```swift
  let reducibleMiddlewareToCancel = try #require(middleware)
  ```
- Replaced direct state checks with `waitForCondition` to make assertions resilient to async timing:
  - wait for `.loading` after `Loading()`
  - wait for `.none` after `CancelLoading()`
- Added an explicit wait until the middleware registers the `reducibleMessage` cancellation entry before dispatching `CancelLoading()`:
  ```swift
  await waitForCondition {
      reducibleMiddlewareToCancel.cancellations[
          ReducibleMiddlewareToCancel.Сancellation.reducibleMessage
      ] != nil
  }
  ```
- Removed the intermediate `store.wait()` call, since the test now synchronizes on the relevant effect lifecycle directly.