### PR TITLE
Add Limn-based implementation for InternalAction.debugDescription

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "5760991a85987a1b5cfe95c180105868dad16ced2b70ab3630b04133cfa1c514",
+  "originHash" : "ba26264ff733afc14574755163bfe931c0295e83f05716ad7d76b0aed92b59ef",
   "pins" : [
+    {
+      "identity" : "limn",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/diogopribeiro/Limn.git",
+      "state" : {
+        "revision" : "b998ebc7cb997188a7ac7afb12a756a9006dc490",
+        "version" : "0.9.3"
+      }
+    },
     {
       "identity" : "runtime",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -21,12 +21,14 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections", from: "1.4.1"),
+        .package(url: "https://github.com/diogopribeiro/Limn", from: "0.8.0"),
         .package(url: "https://github.com/urlaunched-com/Runtime", from: "2.2.6"),
     ],
     targets: [
         .target(
             name: "UDF",
             dependencies: [
+                .product(name: "Limn", package: "Limn"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "Runtime", package: "Runtime"),
             ],
@@ -56,3 +58,4 @@ let package = Package(
         ),
     ]
 )
+

--- a/UDF/Store/Action/PrivateAction/InternalAction.swift
+++ b/UDF/Store/Action/PrivateAction/InternalAction.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import Limn
 
 struct InternalAction: Action {
     let value: any Action
@@ -10,8 +11,16 @@ struct InternalAction: Action {
     var animation: Animation?
     var silent: Bool
     var delay: Delay?
+    let createdAt: Date
+    
+    private var debugDateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        return formatter
+    }
 
-    private let actionDescription: String
+    private let actionMetadataDescription: String
 
     init(
         _ value: some Action,
@@ -29,13 +38,15 @@ struct InternalAction: Action {
         self.lineNumber = lineNumber
         self.silent = silent
         self.delay = delay
-
+        self.createdAt = .now
+        
         let fileURL = NSURL(fileURLWithPath: fileName).lastPathComponent ?? "Unknown file"
+        
         if let animation {
-            actionDescription =
-                "\(String(describing: value)), animation: \(String(describing: animation)) from \(fileURL) - \(functionName) at line \(lineNumber)"
+            actionMetadataDescription =
+                "animation: \(String(describing: animation)) from \(fileURL) - \(functionName) at line \(lineNumber)"
         } else {
-            actionDescription = "\(String(describing: value)) from \(fileURL) - \(functionName) at line \(lineNumber)"
+            actionMetadataDescription = "from \(fileURL) - \(functionName) at line \(lineNumber)"
         }
     }
 }
@@ -50,7 +61,16 @@ extension InternalAction: Equatable {
 // MARK: - CustomDebugStringConvertible
 extension InternalAction: CustomDebugStringConvertible {
     public var debugDescription: String {
-        actionDescription
+        var dumpFormat = Limn.DumpFormat(collectionIndexMinItems: 0)
+        let allOptionalTypeNameComponents: UInt = 0b111
+        let typeNameComponents = OptionalTypeNameComponents(rawValue: allOptionalTypeNameComponents)
+        dumpFormat.typeNameComponents = typeNameComponents
+        dumpFormat.symbols.collectionIndex = "[%d]"
+        let actionDump = Limn(of: value)
+            .stringDump(format: dumpFormat)
+            .replacingOccurrences(of: #"\n+$"#, with: "", options: .regularExpression)
+        
+        return "[\(debugDateFormatter.string(from: createdAt))] \(actionDump), \(actionMetadataDescription)\n"
     }
 }
 

--- a/UDF/Store/Action/PrivateAction/InternalAction.swift
+++ b/UDF/Store/Action/PrivateAction/InternalAction.swift
@@ -61,7 +61,7 @@ extension InternalAction: Equatable {
 // MARK: - CustomDebugStringConvertible
 extension InternalAction: CustomDebugStringConvertible {
     public var debugDescription: String {
-        var dumpFormat = Limn.DumpFormat(collectionIndexMinItems: 0)
+        var dumpFormat = Limn.DumpFormat(maxItems: 5, collectionIndexMinItems: 0)
         let allOptionalTypeNameComponents: UInt = 0b111
         let typeNameComponents = OptionalTypeNameComponents(rawValue: allOptionalTypeNameComponents)
         dumpFormat.typeNameComponents = typeNameComponents

--- a/UDF/Store/Logger/ConsoleDebugLogger.swift
+++ b/UDF/Store/Logger/ConsoleDebugLogger.swift
@@ -35,9 +35,7 @@ public struct ConsoleDebugLogger: ActionLogger {
     ///   - action: The `LoggingAction` to be logged.
     ///   - description: A `String` representing the description of the action.
     public func log(_ action: LoggingAction, description: String) {
-        print(
-            "Reduce\t\t \(description)\n---------------------------------------------------------------------------------------------------------------------------------------------------------------------------"
-        )
+        print(description)
     }
 }
 


### PR DESCRIPTION
### Description
This merge request improves action debugging output by replacing the previous flat string description with a structured dump of the underlying action plus execution metadata. The existing logs only showed `String(describing:)` output and wrapped it in a noisy `Reduce` banner, which made complex actions harder to inspect and reduced the usefulness of debug traces.

The new approach adds a timestamp to each internal action and uses `Limn` to generate richer debug output, making logged actions easier to analyze during store/reducer debugging. An alternative would have been to keep expanding the manual string formatting, but that would still provide limited visibility into nested action payloads compared with a structured dump.

### Changes Made
- Added `Limn` support in `InternalAction` to generate a detailed dump of the wrapped action value in `debugDescription`.
- Added `createdAt: Date` to `InternalAction` and prefixed debug output with a formatted timestamp.
- Reworked action description handling:
  - renamed the stored description field to `actionMetadataDescription`
  - limited it to contextual metadata such as animation, source file, function, and line number
  - separated payload dumping from metadata formatting
- Customized dump formatting for clearer output:
  - always show collection indexes
  - include full optional type name components
  - trim trailing newlines from the generated dump
- Simplified `ConsoleDebugLogger` output by removing the hardcoded `"Reduce"` label and separator line, so it now prints the formatted debug description directly.

### ClickUp task
https://app.clickup.com/t/869eeqxvq


### Example debug window:

```
[2026-08-07 12:42:07.425] UDF.Actions.DidLoadItem<Models.ImageConfigs>(
    item: Models.ImageConfigs(
        baseUrl: "http://image.tmdb.org/t/p/",
        secureBaseUrl: "https://image.tmdb.org/t/p/",
        backdropSizes: [
            [0]: 300,
            [1]: 780,
            [2]: 1280
        ],
        … (2 more),
        profileSizes: [
            [0]: 45,
            [1]: 185,
            [2]: 632
        ],
        stillSizes: [
            [0]: 92,
            [1]: 185,
            [2]: 300
        ]
    ),
    id: UDF.Flows.Id(
        value: "ImageConfigsFlow"
    )
), from ImageConfigsMiddleware.swift - observe(state:) at line 35

[2026-08-07 12:42:07.429] UDF.Actions.DidLoadItems<Models.Genre>(
    items: [
        [0]: Models.Genre(
            id: Models.Genre.ID(
                value: 28
            ),
            name: "Action"
        ),
        [1]: Models.Genre(
            id: Models.Genre.ID(
                value: 12
            ),
            name: "Adventure"
        ),
        [2]: Models.Genre(
            id: Models.Genre.ID(
                value: 16
            ),
            name: "Animation"
        ),
        … (14 more),
        [17]: Models.Genre(
            id: Models.Genre.ID(
                value: 10752
            ),
            name: "War"
        ),
        [18]: Models.Genre(
            id: Models.Genre.ID(
                value: 37
            ),
            name: "Western"
        )
    ],
    id: UDF.Flows.Id(
        value: "MovieGenresFlow"
    ),
    shortDescription: true
), from GenresMiddleware.swift - observe(state:) at line 34

[2026-08-07 12:42:07.433] UDF.Actions.DidLoadItems<Models.Genre>(
    items: [
        [0]: Models.Genre(
            id: Models.Genre.ID(
                value: 10759
            ),
            name: "Action & Adventure"
        ),
        [1]: Models.Genre(
            id: Models.Genre.ID(
                value: 16
            ),
            name: "Animation"
        ),
        [2]: Models.Genre(
            id: Models.Genre.ID(
                value: 35
            ),
            name: "Comedy"
        ),
        … (11 more),
        [14]: Models.Genre(
            id: Models.Genre.ID(
                value: 10768
            ),
            name: "War & Politics"
        ),
        [15]: Models.Genre(
            id: Models.Genre.ID(
                value: 37
            ),
            name: "Western"
        )
    ],
    id: UDF.Flows.Id(
        value: "ShowGenresFlow"
    ),
    shortDescription: true
), from GenresMiddleware.swift - observe(state:) at line 41

[2026-08-07 12:42:07.617] UDF.Actions.DidLoadItems<Models.Genre>(
    items: [
        [0]: Models.Genre(
            id: Models.Genre.ID(
                value: 10759
            ),
            name: "Action & Adventure"
        ),
        [1]: Models.Genre(
            id: Models.Genre.ID(
                value: 16
            ),
            name: "Animation"
        ),
        [2]: Models.Genre(
            id: Models.Genre.ID(
                value: 35
            ),
            name: "Comedy"
        ),
        … (11 more),
        [14]: Models.Genre(
            id: Models.Genre.ID(
                value: 10768
            ),
            name: "War & Politics"
        ),
        [15]: Models.Genre(
            id: Models.Genre.ID(
                value: 37
            ),
            name: "Western"
        )
    ],
    id: UDF.Flows.Id(
        value: "ShowGenresFlow"
    ),
    shortDescription: true
), from GenresMiddleware.swift - observe(state:) at line 41

[2026-08-07 12:42:07.773] (extension in Models):UDF.Actions.LoadHomeSection<Models.MovieSection>(
    sectionId: .popular
), from MainHomeSectionContainer.swift - onContainerDidLoad(store:) at line 41

[2026-08-07 12:42:07.775] (extension in Models):UDF.Actions.LoadHomeSection<Models.MovieSection>(
    sectionId: .nowPlaying
), from HomeSectionContainer.swift - onContainerDidLoad(store:) at line 42

[2026-08-07 12:42:07.775] (extension in Models):UDF.Actions.LoadHomeSection<Models.MovieSection>(
    sectionId: .upcoming
), from HomeSectionContainer.swift - onContainerDidLoad(store:) at line 42

[2026-08-07 12:42:07.775] (extension in Models):UDF.Actions.LoadHomeSection<Models.MovieSection>(
    sectionId: .topRated
), from HomeSectionContainer.swift - onContainerDidLoad(store:) at line 42

[2026-08-07 12:42:07.829] UDF.Actions.DidLoadItems<Models.Movie>(
    items: [
        [0]: Models.Movie(
            id: Models.Movie.ID(
                value: 969681
            ),
            posterPath: "/iPOn6DinuVyLY17YM9mKuPofV08.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        [1]: Models.Movie(
            id: Models.Movie.ID(
                value: 1368337
            ),
            posterPath: "/5rhTDKUhPYvpdQIijFIs5VoWsON.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        [2]: Models.Movie(
            id: Models.Movie.ID(
                value: 634649
            ),
            posterPath: "/1g0dhYtq4irTY1GPXvft6k4YLjm.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        … (15 more),
        [18]: Models.Movie(
            id: Models.Movie.ID(
                value: 980431
            ),
            posterPath: "/3sgnSfNT27Bx5O5ukr7B26mhEQq.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        [19]: Models.Movie(
            id: Models.Movie.ID(
                value: 1375646
            ),
            posterPath: "/tN799oUR0f1gUKDYdMNrDaY7I51.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        )
    ],
    id: UDF.Flows.Id(
        value: "HomeFlow"
    ),
    shortDescription: true
), from HomeMiddleware.swift - reduce(_:for:) at line 32

[2026-08-07 12:42:07.829] UDF.Actions.DidLoadNestedItems<Models.MovieSection, Models.Movie.ID>(
    items: [
        [0]: Models.Movie.ID(
            value: 969681
        ),
        [1]: Models.Movie.ID(
            value: 1368337
        ),
        [2]: Models.Movie.ID(
            value: 634649
        ),
        … (15 more),
        [18]: Models.Movie.ID(
            value: 980431
        ),
        [19]: Models.Movie.ID(
            value: 1375646
        )
    ],
    id: UDF.Flows.Id(
        value: "HomeFlow"
    ),
    shortDescription: true,
    parentId: .popular
), from HomeMiddleware.swift - reduce(_:for:) at line 33

A navigationDestination for “Reviews.ReviewsRoute” was declared earlier on the stack. Only the destination declared closest to the root view of the stack will be used.
[2026-08-07 12:42:07.830] UDF.Actions.DidLoadItems<Models.Movie>(
    items: [
        [0]: Models.Movie(
            id: Models.Movie.ID(
                value: 1368337
            ),
            posterPath: "/5rhTDKUhPYvpdQIijFIs5VoWsON.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        [1]: Models.Movie(
            id: Models.Movie.ID(
                value: 1339713
            ),
            posterPath: "/bRwnj8WEKBCvmfeUNOukJPwB43K.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        [2]: Models.Movie(
            id: Models.Movie.ID(
                value: 1284465
            ),
            posterPath: "/92Tsfx7SFafOqWsotvrlJbHyehd.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        … (15 more),
        [18]: Models.Movie(
            id: Models.Movie.ID(
                value: 1325734
            ),
            posterPath: "/rnIOUhzwJDfgQakx8EjoNyItKgs.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        [19]: Models.Movie(
            id: Models.Movie.ID(
                value: 1101412
            ),
            posterPath: "/p73G56bJGPa5y52cyqWscHR6NnN.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        )
    ],
    id: UDF.Flows.Id(
        value: "HomeFlow"
    ),
    shortDescription: true
), from HomeMiddleware.swift - reduce(_:for:) at line 32

[2026-08-07 12:42:07.830] UDF.Actions.DidLoadNestedItems<Models.MovieSection, Models.Movie.ID>(
    items: [
        [0]: Models.Movie.ID(
            value: 1368337
        ),
        [1]: Models.Movie.ID(
            value: 1339713
        ),
        [2]: Models.Movie.ID(
            value: 1284465
        ),
        … (15 more),
        [18]: Models.Movie.ID(
            value: 1325734
        ),
        [19]: Models.Movie.ID(
            value: 1101412
        )
    ],
    id: UDF.Flows.Id(
        value: "HomeFlow"
    ),
    shortDescription: true,
    parentId: .upcoming
), from HomeMiddleware.swift - reduce(_:for:) at line 33

[2026-08-07 12:42:07.831] UDF.Actions.DidLoadItems<Models.Movie>(
    items: [
        [0]: Models.Movie(
            id: Models.Movie.ID(
                value: 980431
            ),
            posterPath: "/3sgnSfNT27Bx5O5ukr7B26mhEQq.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        [1]: Models.Movie(
            id: Models.Movie.ID(
                value: 1632181
            ),
            posterPath: "/j0CIVzeR7hRAPBPGR54qDZoOQpp.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        [2]: Models.Movie(
            id: Models.Movie.ID(
                value: 1007757
            ),
            posterPath: "/tHhxWxge06goXU6ZQH1hj7vK8Hd.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        … (15 more),
        [18]: Models.Movie(
            id: Models.Movie.ID(
                value: 157336
            ),
            posterPath: "/yQvGrMoipbRoddT0ZR8tPoR7NfX.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        [19]: Models.Movie(
            id: Models.Movie.ID(
                value: 372058
            ),
            posterPath: "/q719jXXEzOoYaps6babgKnONONX.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        )
    ],
    id: UDF.Flows.Id(
        value: "HomeFlow"
    ),
    shortDescription: true
), from HomeMiddleware.swift - reduce(_:for:) at line 32

[2026-08-07 12:42:07.831] UDF.Actions.DidLoadNestedItems<Models.MovieSection, Models.Movie.ID>(
    items: [
        [0]: Models.Movie.ID(
            value: 980431
        ),
        [1]: Models.Movie.ID(
            value: 1632181
        ),
        [2]: Models.Movie.ID(
            value: 1007757
        ),
        … (15 more),
        [18]: Models.Movie.ID(
            value: 157336
        ),
        [19]: Models.Movie.ID(
            value: 372058
        )
    ],
    id: UDF.Flows.Id(
        value: "HomeFlow"
    ),
    shortDescription: true,
    parentId: .topRated
), from HomeMiddleware.swift - reduce(_:for:) at line 33

[2026-08-07 12:42:07.931] UDF.Actions.DidLoadItems<Models.Movie>(
    items: [
        [0]: Models.Movie(
            id: Models.Movie.ID(
                value: 969681
            ),
            posterPath: "/iPOn6DinuVyLY17YM9mKuPofV08.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        [1]: Models.Movie(
            id: Models.Movie.ID(
                value: 1368337
            ),
            posterPath: "/5rhTDKUhPYvpdQIijFIs5VoWsON.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        [2]: Models.Movie(
            id: Models.Movie.ID(
                value: 634649
            ),
            posterPath: "/1g0dhYtq4irTY1GPXvft6k4YLjm.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        … (15 more),
        [18]: Models.Movie(
            id: Models.Movie.ID(
                value: 1630409
            ),
            posterPath: "/qADBUb5ybrkRVGZEFF8Z4RuOwys.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        ),
        [19]: Models.Movie(
            id: Models.Movie.ID(
                value: 1727780
            ),
            posterPath: "/sAA2mjpYJFAKydtzG4P4aHC4mZk.jpg",
            adult: false,
            … (13 more),
            status: "",
            runtime: nil
        )
    ],
    id: UDF.Flows.Id(
        value: "HomeFlow"
    ),
    shortDescription: true
), from HomeMiddleware.swift - reduce(_:for:) at line 32

[2026-08-07 12:42:07.931] UDF.Actions.DidLoadNestedItems<Models.MovieSection, Models.Movie.ID>(
    items: [
        [0]: Models.Movie.ID(
            value: 969681
        ),
        [1]: Models.Movie.ID(
            value: 1368337
        ),
        [2]: Models.Movie.ID(
            value: 634649
        ),
        … (15 more),
        [18]: Models.Movie.ID(
            value: 1630409
        ),
        [19]: Models.Movie.ID(
            value: 1727780
        )
    ],
    id: UDF.Flows.Id(
        value: "HomeFlow"
    ),
    shortDescription: true,
    parentId: .nowPlaying
), from HomeMiddleware.swift - reduce(_:for:) at line 33
```