### PR TITLE
Introduce Storage protocol for passing storage reducers into modules

### DIFF
--- a/Tests/SwiftUI-UDF-Tests/Storage/StorageTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Storage/StorageTests.swift
@@ -84,7 +84,7 @@ private struct AllItemsOrderedDictionary: Storage {
     }
 }
 
-private struct Item: Identifiable, Equatable, Sendable, EmptyValue {
+private struct Item: StorageItem {
     let id: ID
     let name: String
 

--- a/Tests/SwiftUI-UDF-Tests/Storage/StorageTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Storage/StorageTests.swift
@@ -1,0 +1,101 @@
+import OrderedCollections
+import Testing
+@testable import UDF
+
+@Suite struct StorageTests {
+    
+    @Test("Storage reduces entity actions with Dictionary")
+    func storageReducesEntityActionsWithDictionary() {
+        validateStorage(for: AllItemsDictionary())
+    }
+
+    @Test("Storage reduces entity actions with OrderedDictionary")
+    func storageReducesEntityActionsWithOrderedDictionary() {
+        validateStorage(for: AllItemsOrderedDictionary())
+    }
+
+    private func validateStorage<S: Storage>(for storage: S) where S.Entity == Item {
+        var storage = storage
+
+        let apple = Item(id: .init(value: 1), name: "apple")
+        let pineapple = Item(id: .init(value: 2), name: "pineapple")
+        let strawberry = Item(id: .init(value: 3), name: "strawberry")
+        let updatedPineapple = Item(id: pineapple.id, name: "updated pineapple")
+        let missingId = Item.ID(value: 99)
+
+        storage.reduce(Actions.DidLoadItems(items: [apple, pineapple, strawberry], id: "items"))
+        #expect(storage.byId.count == 3, "Storage should contain all loaded items")
+        #expect(storage[apple.id] == apple, "Storage should return the inserted apple by subscript")
+        #expect(storage.by(id: pineapple.id) == pineapple, "Storage should return the inserted pineapple by id")
+
+        storage.reduce(Actions.DidUpdateItem(item: updatedPineapple))
+        #expect(storage.byId.count == 3, "Updating an item should not change storage count")
+        #expect(storage[pineapple.id] == updatedPineapple, "Storage should keep the updated pineapple value")
+
+        storage.reduce(Actions.DeleteItem(item: strawberry))
+        #expect(storage.byId.count == 2, "Deleting an item should reduce storage count by one")
+        #expect(storage[strawberry.id] == nil, "Deleted item should no longer be available in storage")
+    }
+}
+
+private struct AllItemsDictionary: Storage {
+    var byId: [Item.ID: Item] = [:]
+
+    mutating func reduce(_ action: some Action) {
+        switch action {
+        case let action as Actions.DidLoadItems<Item>:
+            byId.insert(items: action.items)
+
+        case let action as Actions.DidLoadItem<Item>:
+            byId.insert(item: action.item)
+
+        case let action as Actions.DidUpdateItem<Item>:
+            byId[action.item.id] = action.item
+
+        case let action as Actions.DeleteItem<Item>:
+            byId.removeValue(forKey: action.item.id)
+
+        default:
+            break
+        }
+    }
+}
+
+private struct AllItemsOrderedDictionary: Storage {
+    var byId: OrderedDictionary<Item.ID, Item> = [:]
+
+    mutating func reduce(_ action: some Action) {
+        switch action {
+        case let action as Actions.DidLoadItems<Item>:
+            byId.insert(items: action.items)
+
+        case let action as Actions.DidLoadItem<Item>:
+            byId.insert(item: action.item)
+
+        case let action as Actions.DidUpdateItem<Item>:
+            byId[action.item.id] = action.item
+
+        case let action as Actions.DeleteItem<Item>:
+            byId.removeValue(forKey: action.item.id)
+
+        default:
+            break
+        }
+    }
+}
+
+private struct Item: Identifiable, Equatable, Sendable, EmptyValue {
+    let id: ID
+    let name: String
+
+    struct ID: Hashable, Sendable {
+        let value: Int
+    }
+    
+    static var empty: Self {
+        .init(
+            id: .init(value: 0),
+            name: ""
+        )
+    }
+}

--- a/Tests/SwiftUI-UDF-Tests/Storage/StorageTests.swift
+++ b/Tests/SwiftUI-UDF-Tests/Storage/StorageTests.swift
@@ -14,7 +14,7 @@ import Testing
         validateStorage(for: AllItemsOrderedDictionary())
     }
 
-    private func validateStorage<S: Storage>(for storage: S) where S.Entity == Item {
+    private func validateStorage(for storage: some Storage<Item>) {
         var storage = storage
 
         let apple = Item(id: .init(value: 1), name: "apple")

--- a/UDF/Domain/Storage/Storage.swift
+++ b/UDF/Domain/Storage/Storage.swift
@@ -1,0 +1,68 @@
+/// A normalized storage reducer that keeps entities indexed by their identifier.
+///
+/// `Storage` is the recommended UDF pattern for storing domain models in a single lookup table instead of duplicating models across
+/// multiple forms or flows. The storage is usually backed by `Dictionary` or
+/// `OrderedDictionary` through the `byId` property.
+///
+/// ## Example
+///
+/// ```swift
+/// struct AllGenres: Storage {
+///     var byId: [Genre.ID: Genre] = [:]
+///
+///     mutating func reduce(_ action: some Action) {
+///         switch action {
+///         case let action as Actions.DidLoadItems<Genre>:
+///             byId.insert(items: action.items)
+///
+///         case let action as Actions.DidLoadItem<Genre>:
+///             byId.insert(item: action.item)
+///
+///         case let action as Actions.DidUpdateItem<Genre>:
+///             byId[action.item.id] = action.item
+///
+///         case let action as Actions.DeleteItem<Genre>:
+///             byId.removeValue(forKey: action.item.id)
+///
+///         default:
+///             break
+///         }
+///     }
+/// }
+/// ```
+///
+/// In this example, `AllGenres` becomes the single source of truth for every loaded
+/// `Genre`. Other reducers can then reference `Genre.ID` values instead of storing
+/// duplicated full models.
+public protocol Storage<Entity>: Reducible {
+    associatedtype Entity: Identifiable & Equatable & Sendable
+    associatedtype Entities: StorageCollection where Entities.Key == Entity.ID, Entities.Value == Entity
+
+    /// The normalized lookup table keyed by entity identifier.
+    var byId: Entities { get set }
+    
+    /// Returns the entity for the provided identifier.
+    ///
+    /// Types conforming to `EmptyValue` can provide a non-optional implementation
+    /// through the default extension below.
+    func by(id: Entity.ID) -> Entity
+}
+
+public extension Storage {
+    /// Convenience access to the underlying storage collection.
+    subscript(id: Entity.ID) -> Entity? {
+        return byId[id]
+    }
+}
+
+public extension Storage where Entity: EmptyValue {
+    /// Returns `.empty` when the entity is missing from storage.
+    func by(id: Entity.ID) -> Entity {
+        self[id] ?? .empty
+    }
+}
+
+/// A helper protocol for entity types that can provide an empty fallback value.
+public protocol EmptyValue {
+    static var empty: Self { get }
+}

--- a/UDF/Domain/Storage/Storage.swift
+++ b/UDF/Domain/Storage/Storage.swift
@@ -35,7 +35,7 @@
 /// `Genre`. Other reducers can then reference `Genre.ID` values instead of storing
 /// duplicated full models.
 public protocol Storage<Entity>: Reducible {
-    associatedtype Entity: Identifiable & Equatable & Sendable
+    associatedtype Entity: StorageItem
     associatedtype Entities: StorageCollection where Entities.Key == Entity.ID, Entities.Value == Entity
 
     /// The normalized lookup table keyed by entity identifier.
@@ -55,14 +55,9 @@ public extension Storage {
     }
 }
 
-public extension Storage where Entity: EmptyValue {
+public extension Storage {
     /// Returns `.empty` when the entity is missing from storage.
     func by(id: Entity.ID) -> Entity {
         self[id] ?? .empty
     }
-}
-
-/// A helper protocol for entity types that can provide an empty fallback value.
-public protocol EmptyValue {
-    static var empty: Self { get }
 }

--- a/UDF/Domain/Storage/StorageCollection.swift
+++ b/UDF/Domain/Storage/StorageCollection.swift
@@ -1,0 +1,23 @@
+/// A collection-like storage abstraction used by `Storage`.
+///
+/// `StorageCollection` allows UDF storage reducers to be backed by different key-value
+/// containers while exposing a consistent API for entity lookup.
+///
+/// Common conforming types in this package are:
+/// - `Dictionary`
+/// - `OrderedDictionary`
+///
+/// Use `Dictionary` when ordering is irrelevant. Use `OrderedDictionary` when you need
+/// stable insertion order in addition to keyed access.
+public protocol StorageCollection: Sequence, Sendable {
+    associatedtype Key: Hashable
+    associatedtype Value
+
+    subscript(key: Key) -> Value? { get set }
+    
+    var count: Int { get }
+    var isEmpty: Bool { get }
+}
+
+extension OrderedDictionary: StorageCollection { }
+extension Dictionary: StorageCollection { }

--- a/UDF/Domain/Storage/StorageItem.swift
+++ b/UDF/Domain/Storage/StorageItem.swift
@@ -1,0 +1,8 @@
+/// A protocol for models that can be stored in a UDF storage reducer.
+///
+/// Conforming types provide an `empty` value that represents missing
+/// or unavailable storage data.
+public protocol StorageItem: Identifiable, Sendable, Equatable {
+    /// A placeholder instance representing the absence of loaded storage data.
+    static var empty: Self { get }
+}


### PR DESCRIPTION
### Description
This merge request introduces a reusable `Storage` abstraction for normalized entity state in the UDF layer.

The problem it addresses is repeated, ad hoc reducer implementations for entity collections stored by identifier. By formalizing this pattern, the codebase gets a single contract for “entity storage” reducers, including typed lookup, optional fallback via `EmptyValue`, and support for different backing collections. This is necessary to make normalized state handling explicit and reusable instead of relying on informal `Dictionary`-based conventions.

An alternative would have been to keep using plain `Dictionary` or `OrderedDictionary` directly in each reducer, but that would continue duplicating the same reducer shape and lookup behavior across features.

### Changes Made
- Added a new `Storage` protocol in `UDF/Domain/Storage/Storage.swift`:
  - defines a normalized `byId` store keyed by `Entity.ID`
  - requires `Entity` to be `Identifiable`, `Equatable`, and `Sendable`
  - adds a common `subscript(id:)` accessor
  - adds default `by(id:)` behavior for `Entity: EmptyValue`, returning `.empty` when missing

- Added `EmptyValue` as a helper protocol to support non-optional fallback reads from storage.

- Added a new `StorageCollection` abstraction in `UDF/Domain/Storage/StorageCollection.swift`:
  - allows `Storage` to be backed by either `Dictionary` or `OrderedDictionary`
  - standardizes the minimal API needed by storage reducers (`subscript`, `count`, `isEmpty`)

- Added tests in `StorageTests.swift` validating reducer behavior against both storage backends:
  - loading multiple items populates the store
  - updating an item replaces the existing value without changing count
  - deleting an item removes it from storage
  - lookup works through both subscript access and `by(id:)`

```swift
public protocol Storage<Entity>: Reducible {
    associatedtype Entity: Identifiable & Equatable & Sendable
    associatedtype Entities: StorageCollection where Entities.Key == Entity.ID, Entities.Value == Entity

    var byId: Entities { get set }
    func by(id: Entity.ID) -> Entity
}
```
This PR introduces the new `Storage` protocol to make storage reducers easier to pass into modules and to standardize normalized entity storage across the library.

### ClickUp task
https://app.clickup.com/t/869ehptvm