### PR TITLE
Preserve @MainActor isolation on Container lifecycle callbacks

### DIFF
--- a/UDF/View/Container/ConnectedContainer.swift
+++ b/UDF/View/Container/ConnectedContainer.swift
@@ -46,7 +46,7 @@ import Runtime
 /// manage its lifecycle events, and bind hooks for actions and side effects.
 struct ConnectedContainer<C: Component, State: AppReducer>: View {
     /// A closure that maps the global store to the properties needed by the component.
-    let map: (_ store: EnvironmentStore<State>) -> C.Props
+    let map: @MainActor (_ store: EnvironmentStore<State>) -> C.Props
     
     /// A closure that defines the scope within the global state.
     let scope: @MainActor (_ state: State) -> Scope
@@ -80,13 +80,13 @@ struct ConnectedContainer<C: Component, State: AppReducer>: View {
     ///   - useHooks: A closure that provides an array of hooks to use within the container.
     init(
         store: EnvironmentStore<State>,
-        map: @escaping (EnvironmentStore<State>) -> C.Props,
+        map: @escaping @MainActor (EnvironmentStore<State>) -> C.Props,
         scope: @escaping @Sendable (State) -> Scope,
         onContainerAppear: @escaping @MainActor (EnvironmentStore<State>) -> Void,
         onContainerDisappear: @escaping @MainActor (EnvironmentStore<State>) -> Void,
-        onContainerDidLoad: @escaping (EnvironmentStore<State>) -> Void,
-        onContainerDidUnload: @escaping (EnvironmentStore<State>) -> Void,
-        useHooks: @escaping () -> [Hook<State>]
+        onContainerDidLoad: @escaping @MainActor (EnvironmentStore<State>) -> Void,
+        onContainerDidUnload: @escaping @MainActor (EnvironmentStore<State>) -> Void,
+        useHooks: @escaping @MainActor () -> [Hook<State>]
     ) {
         self.store = store
         self.map = map
@@ -121,22 +121,22 @@ struct ConnectedContainer<C: Component, State: AppReducer>: View {
         store: EnvironmentStore<State>,
         containerType: BindedContainer.Type,
         containerId: @escaping () -> BindedContainer.ID,
-        map: @escaping (EnvironmentStore<State>) -> C.Props,
+        map: @escaping @MainActor (EnvironmentStore<State>) -> C.Props,
         scope: @escaping @Sendable (State) -> Scope,
         onContainerAppear: @escaping @MainActor (EnvironmentStore<State>) -> Void,
         onContainerDisappear: @escaping @MainActor (EnvironmentStore<State>) -> Void,
-        onContainerDidLoad: @escaping (EnvironmentStore<State>) -> Void,
-        onContainerDidUnload: @escaping (EnvironmentStore<State>) -> Void,
-        onBindableReducerDidLoad: @escaping (EnvironmentStore<State>) -> Void,
-        onBindableReducerDidUnload: @escaping (EnvironmentStore<State>) -> Void,
-        useHooks: @escaping () -> [Hook<State>]
+        onContainerDidLoad: @escaping @MainActor (EnvironmentStore<State>) -> Void,
+        onContainerDidUnload: @escaping @MainActor (EnvironmentStore<State>) -> Void,
+        onBindableReducerDidLoad: @escaping @MainActor (EnvironmentStore<State>) -> Void,
+        onBindableReducerDidUnload: @escaping @MainActor (EnvironmentStore<State>) -> Void,
+        useHooks: @escaping @MainActor () -> [Hook<State>]
     ) where BindedContainer.ID: Sendable {
         self.store = store
         self.map = map
         self.scope = scope
         self.onContainerAppear = onContainerAppear
         self.onContainerDisappear = onContainerDisappear
-        let wrappedUseHooks = {
+        let wrappedUseHooks: @MainActor @Sendable () -> [Hook<State>] = {
             var hooks = useHooks()
             if let syntheticHook = Self.makeStateDidLoadHook(
                 store: store,
@@ -235,7 +235,7 @@ extension ConnectedContainer {
         store: EnvironmentStore<State>,
         containerType: T.Type,
         id: T.ID,
-        onBindableReducerDidLoad: @escaping (EnvironmentStore<State>) -> Void
+        onBindableReducerDidLoad: @escaping @MainActor (EnvironmentStore<State>) -> Void
     ) -> Hook<State>? where T.ID: Sendable {
         guard getBoundReducer(
             from: store.state,
@@ -274,7 +274,7 @@ extension ConnectedContainer {
         containerType: T.Type,
         id: T.ID,
         store: EnvironmentStore<State>,
-        onContainerDidLoad: @escaping (EnvironmentStore<State>) -> Void
+        onContainerDidLoad: @escaping @MainActor (EnvironmentStore<State>) -> Void
     ) {
         let key = BaseContainerLifecycle.ActiveContainerKey(
             containerType: ObjectIdentifier(containerType),
@@ -319,7 +319,7 @@ extension ConnectedContainer {
         containerType: T.Type,
         id: T.ID,
         store: EnvironmentStore<State>,
-        onBindableReducerDidUnload: @escaping (EnvironmentStore<State>) -> Void
+        onBindableReducerDidUnload: @escaping @MainActor (EnvironmentStore<State>) -> Void
     ) {
         let key = BaseContainerLifecycle.ActiveContainerKey(
             containerType: ObjectIdentifier(containerType),

--- a/UDF/View/Container/Container.swift
+++ b/UDF/View/Container/Container.swift
@@ -131,19 +131,19 @@ public protocol Container<ContainerState>: View, Sendable {
 // MARK: - Lifecycle methods
 public extension Container {
     /// Default implementation for `onContainerAppear`. Does nothing by default.
-    func onContainerAppear(store: EnvironmentStore<ContainerState>) {}
+    @MainActor func onContainerAppear(store: EnvironmentStore<ContainerState>) {}
 
     /// Default implementation for `onContainerDisappear`. Does nothing by default.
-    func onContainerDisappear(store: EnvironmentStore<ContainerState>) {}
+    @MainActor func onContainerDisappear(store: EnvironmentStore<ContainerState>) {}
 
     /// Default implementation for `onContainerDidLoad`. Does nothing by default.
-    func onContainerDidLoad(store: EnvironmentStore<ContainerState>) {}
+    @MainActor func onContainerDidLoad(store: EnvironmentStore<ContainerState>) {}
 
     /// Default implementation for `onContainerDidUnload`. Does nothing by default.
-    func onContainerDidUnload(store: EnvironmentStore<ContainerState>) {}
+    @MainActor func onContainerDidUnload(store: EnvironmentStore<ContainerState>) {}
 
     /// Default implementation for `useHooks`. Returns an empty array by default.
-    func useHooks() -> [Hook<ContainerState>] { [] }
+    @MainActor func useHooks() -> [Hook<ContainerState>] { [] }
 }
 
 // MARK: - Store

--- a/UDF/View/Container/ContainerHooks.swift
+++ b/UDF/View/Container/ContainerHooks.swift
@@ -52,14 +52,14 @@ final class ContainerHooks<State: AppReducer>: @unchecked Sendable {
     var hooks: [AnyHashable: Hook<State>] = [:]
 
     /// A closure that returns an array of hooks to be used in the container.
-    var buildHooks: () -> [Hook<State>]
+    var buildHooks: @MainActor () -> [Hook<State>]
 
     /// Initializes the `ContainerHooks` with a store and a closure that builds the hooks.
     ///
     /// - Parameters:
     ///   - store: The `EnvironmentStore` holding the global state.
     ///   - hooks: A closure that provides an array of hooks to use in the container.
-    init(store: EnvironmentStore<State>, hooks: @escaping () -> [Hook<State>]) {
+    init(store: EnvironmentStore<State>, hooks: @escaping @MainActor () -> [Hook<State>]) {
         self.store = store
         self.buildHooks = hooks
         self.subscriptionKey = store.add { [weak self] oldState, newState, _ in
@@ -70,7 +70,7 @@ final class ContainerHooks<State: AppReducer>: @unchecked Sendable {
     }
 
     /// Creates hooks by building them from the provided closure and storing them in a dictionary.
-    func createHooks() {
+    @MainActor func createHooks() {
         self.hooks = Dictionary(uniqueKeysWithValues: buildHooks().map { ($0.id, $0) })
 
         // Trigger initial hook check to ensure hooks fire at least once

--- a/UDF/View/Container/ContainerLifecycle.swift
+++ b/UDF/View/Container/ContainerLifecycle.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// multiple instances of the same container view can temporarily coexist. To prevent race conditions
 /// and premature state unloading, this base class provides a centralized registry to track the active count
 /// of each container key before executing full unload sequences.
-class BaseContainerLifecycle: ObservableObject {
+@MainActor class BaseContainerLifecycle: ObservableObject {
     
     /// A unique key identifying a container type and its specific instance ID.
     ///
@@ -87,13 +87,13 @@ final class ContainerLifecycle<State: AppReducer>: BaseContainerLifecycle {
     var containerHooks: ContainerHooks<State>?
 
     /// A closure that returns an array of hooks to be used in the container.
-    private var useHooks: () -> [Hook<State>]
+    private var useHooks: @MainActor () -> [Hook<State>]
 
     /// A command that is executed when the container is loaded.
-    var didLoadCommand: CommandWith<EnvironmentStore<State>>
+    var didLoadCommand: @MainActor (EnvironmentStore<State>) -> Void
 
     /// A command that is executed when the container is unloaded.
-    var didUnloadCommand: CommandWith<EnvironmentStore<State>>
+    var didUnloadCommand: @MainActor (EnvironmentStore<State>) -> Void
 
     /// A reference to the EnvironmentStore.
     private var store: EnvironmentStore<State> = EnvironmentStore<State>.global
@@ -121,9 +121,9 @@ final class ContainerLifecycle<State: AppReducer>: BaseContainerLifecycle {
     ///   - didUnloadCommand: A command to execute when the container is unloaded.
     ///   - useHooks: A closure that returns an array of hooks to use within the container.
     init(
-        didLoadCommand: @escaping CommandWith<EnvironmentStore<State>>,
-        didUnloadCommand: @escaping CommandWith<EnvironmentStore<State>>,
-        useHooks: @escaping () -> [Hook<State>]
+        didLoadCommand: @escaping @MainActor (EnvironmentStore<State>) -> Void,
+        didUnloadCommand: @escaping @MainActor (EnvironmentStore<State>) -> Void,
+        useHooks: @escaping @MainActor () -> [Hook<State>]
     ) {
         self.didLoadCommand = didLoadCommand
         self.didUnloadCommand = didUnloadCommand
@@ -131,7 +131,7 @@ final class ContainerLifecycle<State: AppReducer>: BaseContainerLifecycle {
     }
 
     /// Cleans up by removing all hooks and executing the unload command.
-    deinit {
+    isolated deinit {
         containerHooks?.removeAllHooks()
         self.didUnloadCommand(self.store)
     }


### PR DESCRIPTION
### Description
This merge request tightens actor isolation around container lifecycle and hook execution by moving container-related callbacks onto the main actor. It addresses concurrency-safety issues in SwiftUI/UDF container code, where mapping props, building hooks, and lifecycle handlers interact with UI state and store-backed lifecycle objects that should execute on the main thread.

These changes are necessary to make actor expectations explicit and consistent across the container stack, especially now that lifecycle state is managed by a `@MainActor` base class and teardown logic also runs in an isolated context. Without this, closures passed through the container pipeline could be invoked from non-main contexts, risking data races or compiler isolation errors.

An alternative would have been to keep the APIs non-isolated and manually hop to the main actor at each call site, but that would spread concurrency handling across the codebase and make lifecycle behavior harder to reason about.

### Changes Made
- Marked container-facing lifecycle and hook APIs as `@MainActor`:
  - `map`
  - `onContainerDidLoad` / `onContainerDidUnload`
  - `onBindableReducerDidLoad` / `onBindableReducerDidUnload`
  - `useHooks`
  - default `Container` lifecycle implementations and `useHooks()`

- Made hook construction explicitly main-actor-bound in `ContainerHooks`:
  - `buildHooks` is now `@MainActor`
  - initializer requires a `@MainActor` hook builder
  - `createHooks()` is now `@MainActor`

- Moved lifecycle coordination to the main actor:
  - `BaseContainerLifecycle` is now `@MainActor`
  - `ContainerLifecycle` stores `didLoadCommand`, `didUnloadCommand`, and `useHooks` as main-actor closures
  - initializer signatures were updated accordingly

- Updated destruction semantics to match actor isolation:
  - `ContainerLifecycle.deinit` is now `isolated deinit`, ensuring hook cleanup and unload callback execution happen within the actor-isolated lifecycle context

- Added explicit typing for wrapped hook composition in `ConnectedContainer`:
  ```swift
  let wrappedUseHooks: @MainActor @Sendable () -> [Hook<State>] = { ... }
  ```
  This preserves both main-actor execution and sendability when synthetic lifecycle hooks are appended.
`Container`'s lifecycle requirements are `@MainActor`, but their default implementations are
nonisolated, and `Container.body` passes them as function values into parameters that drop the
annotation. For containers defined outside the UDF module the compiler then binds to the protocol
extension's default instead of the type's own override, so `onContainerDidLoad`,
`onContainerDidUnload` and `useHooks` are **silently never called**.

The asymmetry is visible in one hunk of `ConnectedContainer.init`:

```swift
onContainerAppear:    @escaping @MainActor (EnvironmentStore<State>) -> Void,  // works
onContainerDidLoad:   @escaping           (EnvironmentStore<State>) -> Void,  // silently ignored
```

Dormant in Swift 6 mode (how `main` builds), active in Swift 5 mode.

**Fix:** keep the isolation instead of relying on inference — `@MainActor` on the five `Container`
extension defaults and on the affected `ConnectedContainer` parameters; `ContainerLifecycle`
becomes `@MainActor` with an `isolated deinit`, which back-deploys at the current iOS 16 floor in
this spelling (no platform bump).